### PR TITLE
Adding support for png mov files

### DIFF
--- a/src/atom_mp4v.cpp
+++ b/src/atom_mp4v.cpp
@@ -138,5 +138,57 @@ void MP4Tsc2Atom::Generate()
 
 ///////////////////////////////////////////////////////////////////////////////
 
+MP4PNGAtom::MP4PNGAtom(MP4File &file)
+   : MP4Atom(file, "png ")
+{
+   AddReserved(*this, "reserved1", 6);
+   AddProperty(new MP4Integer16Property(*this, "dataReferenceIndex"));
+   AddReserved(*this, "reserved2", 16);
+   AddProperty(new MP4Integer16Property(*this, "width"));
+   AddProperty(new MP4Integer16Property(*this, "height"));
+   AddReserved(*this, "reserved3", 14);
+   
+   MP4StringProperty* pProp = new MP4StringProperty(*this, "compressorName");
+   pProp->SetFixedLength(32);
+   pProp->SetCountedFormat(true);
+//   pProp->SetValue("TSC2 Codec");
+   AddProperty(pProp);
+   AddReserved(*this, "reserved4", 4); /* 7 */
+   
+   ExpectChildAtom("colr", Optional, OnlyOne);
+   ExpectChildAtom("esds", Required, OnlyOne);
+   ExpectChildAtom("pasp", Optional, OnlyOne);
+}
+   
+void MP4PNGAtom::Generate()
+{
+   MP4Atom::Generate();
+   
+   ((MP4Integer16Property*)m_pProperties[1])->SetValue(1);
+   
+   // property reserved3 has non-zero fixed values
+   static uint8_t reserved3[14] = {
+      0x00, 0x48, 0x00, 0x00,
+      0x00, 0x48, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00,
+      0x00, 0x01,
+   };
+   m_pProperties[5]->SetReadOnly(false);
+   ((MP4BytesProperty*)m_pProperties[5])->
+   SetValue(reserved3, sizeof(reserved3));
+   m_pProperties[5]->SetReadOnly(true);
+   
+   // property reserved4 has non-zero fixed values
+   static uint8_t reserved4[4] = {
+      0x00, 0x18, 0xFF, 0xFF,
+   };
+   m_pProperties[7]->SetReadOnly(false);
+   ((MP4BytesProperty*)m_pProperties[7])->
+   SetValue(reserved4, sizeof(reserved4));
+   m_pProperties[7]->SetReadOnly(true);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 }
 } // namespace mp4v2::impl

--- a/src/atoms.h
+++ b/src/atoms.h
@@ -271,7 +271,7 @@ private:
     MP4Mp4vAtom &operator= ( const MP4Mp4vAtom &src );
 };
 
-   class MP4Tsc2Atom : public MP4Atom {
+class MP4Tsc2Atom : public MP4Atom {
    public:
       MP4Tsc2Atom(MP4File &file);
       void Generate();
@@ -279,8 +279,17 @@ private:
       MP4Tsc2Atom();
       MP4Tsc2Atom( const MP4Tsc2Atom &src );
       MP4Tsc2Atom &operator= ( const MP4Tsc2Atom &src );
-   };
+};
 
+class MP4PNGAtom : public MP4Atom {
+   public:
+      MP4PNGAtom(MP4File &file);
+      void Generate();
+   private:
+      MP4PNGAtom();
+      MP4PNGAtom( const MP4PNGAtom &src );
+      MP4PNGAtom &operator= ( const MP4PNGAtom &src );
+};
 
 class MP4S263Atom : public MP4Atom {
 public:

--- a/src/mp4atom.cpp
+++ b/src/mp4atom.cpp
@@ -928,6 +928,9 @@ MP4Atom::factory( MP4File &file, MP4Atom* parent, const char* type )
         case 'p':
             if( ATOMID(type) == ATOMID("pasp") )
                 return new MP4PaspAtom(file);
+            if( ATOMID(type) == ATOMID("png ") )
+                return new MP4PNGAtom(file);
+          
             break;
 
         case 'r':
@@ -983,7 +986,6 @@ MP4Atom::factory( MP4File &file, MP4Atom* parent, const char* type )
             if( ATOMID(type) == ATOMID("tsc2") )
                 return new MP4Tsc2Atom(file);
 
-          
             if( ATOMID(type) == ATOMID("twos") )
                 return new MP4SoundAtom( file, type );
             break;


### PR DESCRIPTION
I basically just copied what we did for trecs.  It seems to work.  If the codec is 'png ', we create a MP4PNGAtom, which other than its name, is identical to the other MP4 atoms.