### PR TITLE
Changing the build settings so that it deploys on 10.10

### DIFF
--- a/macBuildReleaseLibs.sh
+++ b/macBuildReleaseLibs.sh
@@ -4,7 +4,7 @@ mkdir build
 cd build
 
 # configure a release version, build it, and copy it to it's destination
-../configure --disable-debug --disable-fvisibility CXXFLAGS="-stdlib=libstdc++"
+../configure --disable-debug --disable-fvisibility CXXFLAGS="-stdlib=libc++ -mmacosx-version-min=10.10"
 make -j8
 cp .libs/*.a ../lib/mac/Release
 


### PR DESCRIPTION
We are still supporting 10.10, so we need to make sure the deployment target is 10.10