### PR TITLE
Fix sample time calculation for times >= 2^32.

### DIFF
--- a/src/mp4track.cpp
+++ b/src/mp4track.cpp
@@ -1071,7 +1071,7 @@ void MP4Track::GetSampleTimes(MP4SampleId sampleId,
     }
 
     for (uint32_t sttsIndex = m_cachedSttsIndex; sttsIndex < numStts; sttsIndex++) {
-        uint32_t sampleCount =
+        uint64_t sampleCount =
             m_pSttsSampleCountProperty->GetValue(sttsIndex);
         uint32_t sampleDelta =
             m_pSttsSampleDeltaProperty->GetValue(sttsIndex);
@@ -1109,7 +1109,7 @@ MP4SampleId MP4Track::GetSampleIdFromTime(
     MP4Duration elapsed = 0;
 
     for (uint32_t sttsIndex = 0; sttsIndex < numStts; sttsIndex++) {
-        uint32_t sampleCount =
+        uint64_t sampleCount =
             m_pSttsSampleCountProperty->GetValue(sttsIndex);
         uint32_t sampleDelta =
             m_pSttsSampleDeltaProperty->GetValue(sttsIndex);


### PR DESCRIPTION
An issue handling long MP4 files containing audio books with hundreds of chapters was reported by a fre:ac user. Turned out the issue is with MP4v2.

In MP4Track::GetSampleTimes and MP4Track::GetSampleIdFromTime, sampleCount is a 32 bit value that is later multiplied by sampleDelta in 32 bit math. We need this multiplication to happen in 64 bit math to handle long tracks, so promote sampleCount to a 64 bit variable.

An alternative solution would be to add casts to uint64_t where the multiplications happen, but changing the value type seemed more elegant to me. If you prefer it the other way, I can change this PR accordingly.