### PR TITLE
Adjustments for ProRes MOV files

### DIFF
--- a/mp4v2-Win/include/mp4v2/project.h
+++ b/mp4v2-Win/include/mp4v2/project.h
@@ -6,17 +6,17 @@
 #define MP4V2_PROJECT_name            "MP4v2"
 #define MP4V2_PROJECT_name_lower      "mp4v2"
 #define MP4V2_PROJECT_name_upper      "MP4V2"
-#define MP4V2_PROJECT_name_formal     "MP4v2 4.1.0.0"
+#define MP4V2_PROJECT_name_formal     "MP4v2 4.1.1.0"
 #define MP4V2_PROJECT_url_website     "http://code.google.com/p/mp4v2"
 #define MP4V2_PROJECT_url_downloads   "http://code.google.com/p/mp4v2/downloads/list"
 #define MP4V2_PROJECT_url_discussion  "http://groups.google.com/group/mp4v2"
 #define MP4V2_PROJECT_irc             "irc://irc.freenode.net/handbrake"
 #define MP4V2_PROJECT_bugreport       "<eddyg@myreflection.org>"
-#define MP4V2_PROJECT_version         "4.1.0.0"
+#define MP4V2_PROJECT_version         "4.1.1.0"
 #define MP4V2_PROJECT_version_hex     0x00020100
 #define MP4V2_PROJECT_version_major   4
 #define MP4V2_PROJECT_version_minor   1
-#define MP4V2_PROJECT_version_point   0
+#define MP4V2_PROJECT_version_point   1
 #define MP4V2_PROJECT_repo_url        "https://mp4v2.googlecode.com/svn/trunk"
 #define MP4V2_PROJECT_repo_root       "https://mp4v2.googlecode.com/svn"
 #define MP4V2_PROJECT_repo_uuid       "6e6572fa-98a6-11dd-ad9f-f77439c74b79"

--- a/mp4v2-Win/include/mp4v2/project.h
+++ b/mp4v2-Win/include/mp4v2/project.h
@@ -6,17 +6,17 @@
 #define MP4V2_PROJECT_name            "MP4v2"
 #define MP4V2_PROJECT_name_lower      "mp4v2"
 #define MP4V2_PROJECT_name_upper      "MP4V2"
-#define MP4V2_PROJECT_name_formal     "MP4v2 4.1.1.0"
+#define MP4V2_PROJECT_name_formal     "MP4v2 4.1.2.0"
 #define MP4V2_PROJECT_url_website     "http://code.google.com/p/mp4v2"
 #define MP4V2_PROJECT_url_downloads   "http://code.google.com/p/mp4v2/downloads/list"
 #define MP4V2_PROJECT_url_discussion  "http://groups.google.com/group/mp4v2"
 #define MP4V2_PROJECT_irc             "irc://irc.freenode.net/handbrake"
 #define MP4V2_PROJECT_bugreport       "<eddyg@myreflection.org>"
-#define MP4V2_PROJECT_version         "4.1.1.0"
+#define MP4V2_PROJECT_version         "4.1.2.0"
 #define MP4V2_PROJECT_version_hex     0x00020100
 #define MP4V2_PROJECT_version_major   4
 #define MP4V2_PROJECT_version_minor   1
-#define MP4V2_PROJECT_version_point   1
+#define MP4V2_PROJECT_version_point   2
 #define MP4V2_PROJECT_repo_url        "https://mp4v2.googlecode.com/svn/trunk"
 #define MP4V2_PROJECT_repo_root       "https://mp4v2.googlecode.com/svn"
 #define MP4V2_PROJECT_repo_uuid       "6e6572fa-98a6-11dd-ad9f-f77439c74b79"

--- a/mp4v2-Win/include/mp4v2/project.h
+++ b/mp4v2-Win/include/mp4v2/project.h
@@ -6,13 +6,13 @@
 #define MP4V2_PROJECT_name            "MP4v2"
 #define MP4V2_PROJECT_name_lower      "mp4v2"
 #define MP4V2_PROJECT_name_upper      "MP4V2"
-#define MP4V2_PROJECT_name_formal     "MP4v2 4.1.2.0"
+#define MP4V2_PROJECT_name_formal     "MP4v2 4.1.3.0"
 #define MP4V2_PROJECT_url_website     "http://code.google.com/p/mp4v2"
 #define MP4V2_PROJECT_url_downloads   "http://code.google.com/p/mp4v2/downloads/list"
 #define MP4V2_PROJECT_url_discussion  "http://groups.google.com/group/mp4v2"
 #define MP4V2_PROJECT_irc             "irc://irc.freenode.net/handbrake"
 #define MP4V2_PROJECT_bugreport       "<eddyg@myreflection.org>"
-#define MP4V2_PROJECT_version         "4.1.2.0"
+#define MP4V2_PROJECT_version         "4.1.3.0"
 #define MP4V2_PROJECT_version_hex     0x00020100
 #define MP4V2_PROJECT_version_major   4
 #define MP4V2_PROJECT_version_minor   1

--- a/mp4v2-Win/mp4v2.autopkg
+++ b/mp4v2-Win/mp4v2.autopkg
@@ -10,7 +10,7 @@ nuget
    nuspec
    {
       id = mp4v2;
-      version: 4.1.0.0;
+      version: 4.1.1;
       title: MP4v2 Library;
       authors: { TechSmith Corporation };
       owners: { TechSmith Corporation };
@@ -30,7 +30,8 @@ nuget
          3.0.3.0 Fixing a bug where version number 3.0.2 was inconsistent in project.h
          4.0.0.0 Updated to Visual Studio 2017
          4.0.1.0 Fix autopkg file
-         4.1.0.0 Security fixes";
+         4.1.0.0 Security fixes
+         4.1.1   (pre-release) Be more tolerant of some MOV-specific quirks";
       copyright: "";
       tags: { native, mp4v2, mp4, vs2017 };
    };

--- a/mp4v2-Win/mp4v2.autopkg
+++ b/mp4v2-Win/mp4v2.autopkg
@@ -10,7 +10,7 @@ nuget
    nuspec
    {
       id = mp4v2;
-      version: 4.1.2;
+      version: 4.1.3;
       title: MP4v2 Library;
       authors: { TechSmith Corporation };
       owners: { TechSmith Corporation };
@@ -32,7 +32,8 @@ nuget
          4.0.1.0 Fix autopkg file
          4.1.0.0 Security fixes
          4.1.1   (pre-release) Be more tolerant of some MOV-specific quirks
-         4.1.2   Finalize changes to handle ProRes MOV files correctly";
+         4.1.2   Finalize changes to handle ProRes MOV files correctly
+         4.1.3   ftyp atom optional for MOV files";
       copyright: "";
       tags: { native, mp4v2, mp4, vs2017 };
    };

--- a/mp4v2-Win/mp4v2.autopkg
+++ b/mp4v2-Win/mp4v2.autopkg
@@ -10,7 +10,7 @@ nuget
    nuspec
    {
       id = mp4v2;
-      version: 4.1.1;
+      version: 4.1.1-pre;
       title: MP4v2 Library;
       authors: { TechSmith Corporation };
       owners: { TechSmith Corporation };

--- a/mp4v2-Win/mp4v2.autopkg
+++ b/mp4v2-Win/mp4v2.autopkg
@@ -10,7 +10,7 @@ nuget
    nuspec
    {
       id = mp4v2;
-      version: 4.1.1-pre;
+      version: 4.1.2;
       title: MP4v2 Library;
       authors: { TechSmith Corporation };
       owners: { TechSmith Corporation };
@@ -31,7 +31,8 @@ nuget
          4.0.0.0 Updated to Visual Studio 2017
          4.0.1.0 Fix autopkg file
          4.1.0.0 Security fixes
-         4.1.1   (pre-release) Be more tolerant of some MOV-specific quirks";
+         4.1.1   (pre-release) Be more tolerant of some MOV-specific quirks
+         4.1.2   Finalize changes to handle ProRes MOV files correctly";
       copyright: "";
       tags: { native, mp4v2, mp4, vs2017 };
    };

--- a/src/mp4track.cpp
+++ b/src/mp4track.cpp
@@ -906,8 +906,15 @@ File* MP4Track::GetSampleFile( MP4SampleId sampleId )
        // in local file" case... for our purposes, we don't care about cases where the
        // media data is outside of the local file.
        MP4FtypAtom *pFtypAtom = reinterpret_cast<MP4FtypAtom *>( m_File.FindAtom( "ftyp" ) );
-       if ( pFtypAtom != nullptr )
+
+       // MOV spec does not require "ftyp" atom...
+       if ( pFtypAtom == nullptr )
        {
+          return nullptr;
+       }
+       else
+       {
+          // ... but most often it is present with a "qt  " value
           const char *majorBrand = pFtypAtom->majorBrand.GetValue();
           if ( ::strcmp( pFtypAtom->majorBrand.GetValue(), "qt  " ) == 0 )
              return nullptr;

--- a/src/mp4track.cpp
+++ b/src/mp4track.cpp
@@ -901,7 +901,8 @@ File* MP4Track::GetSampleFile( MP4SampleId sampleId )
     if( !pStsdEntryAtom->FindProperty( "*.dataReferenceIndex", (MP4Property**)&pDrefIndexProperty ) ||
         pDrefIndexProperty == NULL )
     {
-        throw new Exception( "invalid stsd entry", __FILE__, __LINE__, __FUNCTION__ );
+        //throw new Exception( "invalid stsd entry", __FILE__, __LINE__, __FUNCTION__ );
+       return NULL;
     }
 
     uint32_t drefIndex = pDrefIndexProperty->GetValue();

--- a/src/mp4track.cpp
+++ b/src/mp4track.cpp
@@ -901,8 +901,18 @@ File* MP4Track::GetSampleFile( MP4SampleId sampleId )
     if( !pStsdEntryAtom->FindProperty( "*.dataReferenceIndex", (MP4Property**)&pDrefIndexProperty ) ||
         pDrefIndexProperty == NULL )
     {
-        //throw new Exception( "invalid stsd entry", __FILE__, __LINE__, __FUNCTION__ );
-       return NULL;
+       // mp4v2 does not know about Apple-specific atoms in MOV files so may fail to find
+       // the DataReferenceIndex. In that case, we'll handle it the same as the "media data
+       // in local file" case... for our purposes, we don't care about cases where the
+       // media data is outside of the local file.
+       MP4FtypAtom *pFtypAtom = reinterpret_cast<MP4FtypAtom *>( m_File.FindAtom( "ftyp" ) );
+       if ( pFtypAtom != nullptr )
+       {
+          const char *majorBrand = pFtypAtom->majorBrand.GetValue();
+          if ( ::strcmp( pFtypAtom->majorBrand.GetValue(), "qt  " ) == 0 )
+             return nullptr;
+       }
+       throw new Exception( "invalid stsd entry", __FILE__, __LINE__, __FUNCTION__ );
     }
 
     uint32_t drefIndex = pDrefIndexProperty->GetValue();


### PR DESCRIPTION
ProRes MOV files contain some Apple-specific atoms that are not publicly documented. Consequently, mp4v2 was failing to parse out some information for ProRes video tracks:
* width/height
* data reference (the odd case where media data is not self contained within the file).
With this change:
* if we fail to retrieve the width/height, we'll just use the width/height from the track header atom
* if we fail to find data reference info under the stsd atom and we are a QuickTime MOV, we'll just assume the media data is self-contained within the file (this is the only case we care about anyway).