### PR TITLE
Fix GCC7 build

### DIFF
--- a/src/rtphint.cpp
+++ b/src/rtphint.cpp
@@ -339,7 +339,7 @@ void MP4RtpHintTrack::GetPayload(
                 pSlash = strchr(pSlash, '/');
                 if (pSlash != NULL) {
                     pSlash++;
-                    if (pSlash != '\0') {
+                    if (*pSlash != '\0') {
                         length = (uint32_t)strlen(pRtpMap) - (pSlash - pRtpMap);
                         *ppEncodingParams = (char *)MP4Calloc(length + 1);
                         strncpy(*ppEncodingParams, pSlash, length);


### PR DESCRIPTION
if (*pSlash != '\0') {

As it stands the body of that if will always execute and when there are
no encoding parameters ppEncodingParams will be returned as a pointer to
an empty string rather than as a null pointer

Signed-off-by: Peter Korsgaard <peter@korsgaard.com>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/mp4v2/0001-Fix-GCC7-build.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>