### PR TITLE
Allow some parsing to be skipped

### DIFF
--- a/include/mp4v2/file.h
+++ b/include/mp4v2/file.h
@@ -328,9 +328,12 @@ bool MP4Optimize(
  *      the library.
  *      On error, #MP4_INVALID_FILE_HANDLE.
  */
+typedef bool( *ShouldParseAtomCallback )( uint32_t );
+
 MP4V2_EXPORT
 MP4FileHandle MP4Read(
-    const char* fileName );
+    const char* fileName,
+    ShouldParseAtomCallback cb = nullptr );
 
 /** Read an existing mp4 file.
  *
@@ -357,13 +360,6 @@ MP4V2_EXPORT
 MP4FileHandle MP4ReadProvider(
     const char*            fileName,
     const MP4FileProvider* fileProvider DEFAULT(NULL) );
-
-typedef bool( *ShouldParseAtomCallback )( uint32_t );
-MP4V2_EXPORT
-void MP4SetShouldParseAtomCallback(
-   MP4FileHandle hFile,
-   ShouldParseAtomCallback f
-);
 
 /** @} ***********************************************************************/
 

--- a/include/mp4v2/file.h
+++ b/include/mp4v2/file.h
@@ -361,6 +361,7 @@ MP4FileHandle MP4ReadProvider(
 typedef bool( *ShouldParseAtomCallback )( uint32_t );
 MP4V2_EXPORT
 void MP4SetShouldParseAtomCallback(
+   MP4FileHandle hFile,
    ShouldParseAtomCallback f
 );
 

--- a/include/mp4v2/file.h
+++ b/include/mp4v2/file.h
@@ -358,6 +358,12 @@ MP4FileHandle MP4ReadProvider(
     const char*            fileName,
     const MP4FileProvider* fileProvider DEFAULT(NULL) );
 
+typedef bool( *ShouldParseAtomCallback )( uint32_t );
+MP4V2_EXPORT
+void MP4SetShouldParseAtomCallback(
+   ShouldParseAtomCallback f
+);
+
 /** @} ***********************************************************************/
 
 #endif /* MP4V2_FILE_H */

--- a/mp4v2-Win/include/mp4v2/project.h
+++ b/mp4v2-Win/include/mp4v2/project.h
@@ -6,17 +6,17 @@
 #define MP4V2_PROJECT_name            "MP4v2"
 #define MP4V2_PROJECT_name_lower      "mp4v2"
 #define MP4V2_PROJECT_name_upper      "MP4V2"
-#define MP4V2_PROJECT_name_formal     "MP4v2 4.1.3.0"
+#define MP4V2_PROJECT_name_formal     "MP4v2 4.1.4.0"
 #define MP4V2_PROJECT_url_website     "http://code.google.com/p/mp4v2"
 #define MP4V2_PROJECT_url_downloads   "http://code.google.com/p/mp4v2/downloads/list"
 #define MP4V2_PROJECT_url_discussion  "http://groups.google.com/group/mp4v2"
 #define MP4V2_PROJECT_irc             "irc://irc.freenode.net/handbrake"
 #define MP4V2_PROJECT_bugreport       "<eddyg@myreflection.org>"
-#define MP4V2_PROJECT_version         "4.1.3.0"
+#define MP4V2_PROJECT_version         "4.1.4.0"
 #define MP4V2_PROJECT_version_hex     0x00020100
 #define MP4V2_PROJECT_version_major   4
 #define MP4V2_PROJECT_version_minor   1
-#define MP4V2_PROJECT_version_point   2
+#define MP4V2_PROJECT_version_point   4
 #define MP4V2_PROJECT_repo_url        "https://mp4v2.googlecode.com/svn/trunk"
 #define MP4V2_PROJECT_repo_root       "https://mp4v2.googlecode.com/svn"
 #define MP4V2_PROJECT_repo_uuid       "6e6572fa-98a6-11dd-ad9f-f77439c74b79"

--- a/mp4v2-Win/libmp4v2/libmp4v2.vcxproj
+++ b/mp4v2-Win/libmp4v2/libmp4v2.vcxproj
@@ -22,30 +22,30 @@
     <ProjectGuid>{BDB97A37-90B8-4906-BCAB-663D983E33E3}</ProjectGuid>
     <RootNamespace>libmp4v2</RootNamespace>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>false</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v141</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/mp4v2-Win/mp4v2.autopkg
+++ b/mp4v2-Win/mp4v2.autopkg
@@ -2,7 +2,7 @@ configurations
 {
    Toolset {
       key : "PlatformToolset";
-      choices: { v141 };
+      choices: { v142 };
    };
 }
 nuget
@@ -10,7 +10,7 @@ nuget
    nuspec
    {
       id = mp4v2;
-      version: 4.1.3;
+      version: 4.1.4;
       title: MP4v2 Library;
       authors: { TechSmith Corporation };
       owners: { TechSmith Corporation };
@@ -33,7 +33,8 @@ nuget
          4.1.0.0 Security fixes
          4.1.1   (pre-release) Be more tolerant of some MOV-specific quirks
          4.1.2   Finalize changes to handle ProRes MOV files correctly
-         4.1.3   ftyp atom optional for MOV files";
+         4.1.3   ftyp atom optional for MOV files
+         4.1.4   Update to VS 2019; allow parsing of some atoms to be skipped";
       copyright: "";
       tags: { native, mp4v2, mp4, vs2017 };
    };
@@ -42,7 +43,7 @@ nuget
    {
       nestedInclude:  { #destination = ${d_include}mp4v2; ..\include\mp4v2\*.h };
 
-      ("Win32,x64", "v141", "Debug,Release") =>
+      ("Win32,x64", "v142", "Debug,Release") =>
       {
          [${0},${1},${2}]
          {

--- a/src/mp4.cpp
+++ b/src/mp4.cpp
@@ -87,7 +87,7 @@ const char* MP4GetFilename( MP4FileHandle hFile )
 
 ///////////////////////////////////////////////////////////////////////////////
 
-MP4FileHandle MP4Read( const char* fileName )
+MP4FileHandle MP4Read( const char* fileName, ShouldParseAtomCallback cb/*=nullptr*/ )
 {
     if (!fileName)
         return MP4_INVALID_FILE_HANDLE;
@@ -99,6 +99,10 @@ MP4FileHandle MP4Read( const char* fileName )
     try
     {
         ASSERT(pFile);
+
+        if ( cb != nullptr )
+           pFile->SetShouldParseAtomCallback( cb );
+
         pFile->Read( fileName, NULL );
         return (MP4FileHandle)pFile;
     }
@@ -141,30 +145,6 @@ MP4FileHandle MP4ReadProvider( const char* fileName, const MP4FileProvider* file
     if (pFile)
         delete pFile;
     return MP4_INVALID_FILE_HANDLE;
-}
-
-///////////////////////////////////////////////////////////////////////////////
-
-void MP4SetShouldParseAtomCallback( MP4FileHandle hFile, ShouldParseAtomCallback cb )
-{
-   if (!MP4_IS_VALID_FILE_HANDLE(hFile))
-      return;
-   try
-   {
-      ASSERT(hFile);
-      MP4File& file = *static_cast<MP4File*>(hFile);
-      file.SetShouldParseAtomCallback( cb );
-   }
-   catch( Exception* x ) {
-      mp4v2::impl::log.errorf(*x);
-      delete x;
-   }
-   catch( ... ) {
-      mp4v2::impl::log.errorf("%s: unknown exception accessing MP4File "
-                               "filename", __FUNCTION__ );
-   }
-
-//   g_parseCallback = cb;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/mp4.cpp
+++ b/src/mp4.cpp
@@ -38,14 +38,6 @@
 
 #include "src/impl.h"
 
-namespace mp4v2
-{
-   namespace impl
-   {
-      ShouldParseAtomCallback g_parseCallback = nullptr;
-   }
-}
-
 using namespace mp4v2::impl;
 
 static MP4File  *ConstructMP4File ( void )
@@ -153,9 +145,26 @@ MP4FileHandle MP4ReadProvider( const char* fileName, const MP4FileProvider* file
 
 ///////////////////////////////////////////////////////////////////////////////
 
-void MP4SetShouldParseAtomCallback( ShouldParseAtomCallback cb )
+void MP4SetShouldParseAtomCallback( MP4FileHandle hFile, ShouldParseAtomCallback cb )
 {
-   g_parseCallback = cb;
+   if (!MP4_IS_VALID_FILE_HANDLE(hFile))
+      return;
+   try
+   {
+      ASSERT(hFile);
+      MP4File& file = *static_cast<MP4File*>(hFile);
+      file.SetShouldParseAtomCallback( cb );
+   }
+   catch( Exception* x ) {
+      mp4v2::impl::log.errorf(*x);
+      delete x;
+   }
+   catch( ... ) {
+      mp4v2::impl::log.errorf("%s: unknown exception accessing MP4File "
+                               "filename", __FUNCTION__ );
+   }
+
+//   g_parseCallback = cb;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/mp4.cpp
+++ b/src/mp4.cpp
@@ -38,6 +38,14 @@
 
 #include "src/impl.h"
 
+namespace mp4v2
+{
+   namespace impl
+   {
+      ShouldParseAtomCallback g_parseCallback = nullptr;
+   }
+}
+
 using namespace mp4v2::impl;
 
 static MP4File  *ConstructMP4File ( void )
@@ -141,6 +149,13 @@ MP4FileHandle MP4ReadProvider( const char* fileName, const MP4FileProvider* file
     if (pFile)
         delete pFile;
     return MP4_INVALID_FILE_HANDLE;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+void MP4SetShouldParseAtomCallback( ShouldParseAtomCallback cb )
+{
+   g_parseCallback = cb;
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/mp4atom.cpp
+++ b/src/mp4atom.cpp
@@ -237,7 +237,7 @@ void MP4Atom::Read()
 
     // skip parsing of certain atoms
     ShouldParseAtomCallback cb = m_File.GetShouldParseAtomCallback();
-    if ( cb == nullptr || ( cb != nullptr && cb( ATOMID(m_type) ) ) )
+    if ( cb == nullptr || cb( ATOMID(m_type) ) )
     {
        ReadProperties();
 

--- a/src/mp4atom.cpp
+++ b/src/mp4atom.cpp
@@ -227,6 +227,8 @@ bool MP4Atom::IsReasonableType(const char* type)
     return false;
 }
 
+extern ShouldParseAtomCallback g_parseCallback;
+
 // generic read
 void MP4Atom::Read()
 {
@@ -235,11 +237,16 @@ void MP4Atom::Read()
                      m_File.GetFilename().c_str(), m_type, m_size);
     }
 
-    ReadProperties();
+    // skip parsing of certain atoms
+    if ( g_parseCallback != nullptr && g_parseCallback( ATOMID(m_type) ) )
+    {
+       ReadProperties();
 
-    // read child atoms, if we expect there to be some
-    if (m_pChildAtomInfos.Size() > 0) {
-        ReadChildAtoms();
+       // read child atoms, if we expect there to be some
+       if ( m_pChildAtomInfos.Size() > 0 )
+       {
+          ReadChildAtoms();
+       }
     }
 
     Skip(); // to end of atom

--- a/src/mp4atom.cpp
+++ b/src/mp4atom.cpp
@@ -227,8 +227,6 @@ bool MP4Atom::IsReasonableType(const char* type)
     return false;
 }
 
-extern ShouldParseAtomCallback g_parseCallback;
-
 // generic read
 void MP4Atom::Read()
 {
@@ -238,7 +236,8 @@ void MP4Atom::Read()
     }
 
     // skip parsing of certain atoms
-    if ( g_parseCallback != nullptr && g_parseCallback( ATOMID(m_type) ) )
+    ShouldParseAtomCallback cb = m_File.GetShouldParseAtomCallback();
+    if ( cb == nullptr || ( cb != nullptr && cb( ATOMID(m_type) ) ) )
     {
        ReadProperties();
 

--- a/src/mp4file.cpp
+++ b/src/mp4file.cpp
@@ -66,6 +66,8 @@ void MP4File::Init()
     m_bufWriteBits = 0;
     m_editName = NULL;
     m_trakName[0] = '\0';
+
+    m_shouldParseAtomCallback = nullptr;
 }
 
 MP4File::~MP4File()

--- a/src/mp4file.h
+++ b/src/mp4file.h
@@ -855,6 +855,15 @@ public:
         MP4Atom* pAncestorAtom,
         const char* childName);
 
+    ShouldParseAtomCallback GetShouldParseAtomCallback() const
+    {
+       return m_shouldParseAtomCallback;
+    }
+    void SetShouldParseAtomCallback( ShouldParseAtomCallback cb )
+    {
+       m_shouldParseAtomCallback = cb;
+    }
+
 protected:
     void Init();
     void Open( const char* name, File::Mode mode, const MP4FileProvider* provider );
@@ -988,6 +997,8 @@ protected:
 
     char m_trakName[1024];
     char *m_editName;
+
+    ShouldParseAtomCallback m_shouldParseAtomCallback;
 
  private:
     MP4File ( const MP4File &src );


### PR DESCRIPTION
We have a couple of bugs where files that imported in earlier versions of Camtasia no longer import. They are both due to MP4Read() failing due to something being out-of-spec in atoms that we aren't interested in anyway. So the change here is just to add a client callback that tells mp4v2 whether to parse or skip over a given atom (specified by the atom's four-cc.).