### PR TITLE
Fix static linking via CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,7 @@ target_include_directories(mp4v2 PRIVATE
    ${CMAKE_CURRENT_SOURCE_DIR}/include
    )
 
-target_compile_definitions(mp4v2 PRIVATE MP4V2_USE_STATIC_LIB)
+target_compile_definitions(mp4v2 PUBLIC MP4V2_USE_STATIC_LIB)
 
 
 #set(UTILITY_HEADERS


### PR DESCRIPTION
by making the compile definition public, so clients don't need to
specify this flag.