### PR TITLE
Add more JPEG image headers

### DIFF
--- a/src/itmf/type.cpp
+++ b/src/itmf/type.cpp
@@ -281,10 +281,14 @@ namespace {
 
     // POD static init does not need singletons
     static ImageHeader IMAGE_HEADERS[] = {
+        // https://en.wikipedia.org/wiki/List_of_file_signatures
         { BT_BMP,  "\x42\x4d" },
         { BT_GIF,  "GIF87a" },
         { BT_GIF,  "GIF89a" },
-        { BT_JPEG, "\xff\xd8\xff\xe0" },
+        { BT_JPEG, "\xff\xd8\xff\xdb" }, // raw jpeg (SOI -> DQT)
+        { BT_JPEG, "\xff\xd8\xff\xe0\x00\x10\x4a\x46\x49\x46\x00\x01" }, // JFIF (SOI -> APP0 JFIF)
+        { BT_JPEG, "\xff\xd8\xff\xee" }, // Adobe(?) (SOI -> APP14)
+        { BT_JPEG, "\xff\xd8\xff\xe1" }, // Exif (SOI -> APP1 Exif) (real: FF D8 FF E1 ?? ?? 45 78 69 66 00 00)
         { BT_PNG,  "\x89\x50\x4e\x47\x0d\x0a\x1a\x0a" },
         { BT_UNDEFINED } // must be last
     };


### PR DESCRIPTION
When adding cover arts with `mp4art --add cover.jpg music.mp4`, some JPEG images get added as `implicit` type:
```
$ file cover.jpg
cover.jpg: JPEG image data, baseline, precision 8, 400x300, components 3

$ mp4art --add cover.jpg music.mp4
adding cover.jpg -> music.mp4

$ mp4art --list music.mp4
IDX     BYTES  CRC32     TYPE       FILE
----------------------------------------------------------------------
  0     76020  4a9ed6db  implicit   music.mp4
```

in `type.cpp`:
https://github.com/TechSmith/mp4v2/blob/4fc9463600ea4313c3ddb6fe2c7a2a4c4b2cadd7/src/itmf/type.cpp#L283-L290
According to https://en.wikipedia.org/wiki/List_of_file_signatures, `"\xff\xd8\xff\xe0"` can only detect JPEG in JFIF formats.
This commit added support for detecting raw JPEG and JPEG in Exif, so when adding arts, they won't get `BasicType` undetected.