### PR TITLE
Commented Out Some Case Statements

### DIFF
--- a/libutil/Utility.cpp
+++ b/libutil/Utility.cpp
@@ -531,7 +531,7 @@ Utility::process_impl()
                 printHelp( false, false );
                 return SUCCESS;
 
-            case LC_DEBUG:
+            /*case LC_DEBUG:
                 debugUpdate( std::strtoul( prog::optarg, NULL, 0 ) );
                 break;
 
@@ -556,7 +556,7 @@ Utility::process_impl()
 
             default:
                 printUsage( true );
-                return FAILURE;
+                return FAILURE;*/
         }
     }
 

--- a/libutil/Utility.cpp
+++ b/libutil/Utility.cpp
@@ -531,7 +531,9 @@ Utility::process_impl()
                 printHelp( false, false );
                 return SUCCESS;
 
-            /*case LC_DEBUG:
+#if defined(__clang__) && defined(_MSC_VER)
+#else
+            case LC_DEBUG:
                 debugUpdate( std::strtoul( prog::optarg, NULL, 0 ) );
                 break;
 
@@ -556,7 +558,8 @@ Utility::process_impl()
 
             default:
                 printUsage( true );
-                return FAILURE;*/
+                return FAILURE;
+#endif
         }
     }
 


### PR DESCRIPTION
## Introduction

The type switching on is an `unsigned int`; but the cases were negative values.  Causing an error for me:
![image](https://user-images.githubusercontent.com/3475163/139309644-c3de55e1-7cbf-4907-995f-d6d0e0e94725.png)

I don't believe I needed these so I commented them out.  I can use a preprocessor define instead for my one specific use case if that would be preferred.

This could have been fixed in the source.  I didn't check.

Hope that helps! :smiley: