### PR TITLE
src/mp4track.cpp: replace nullptr by NULL

### DIFF
--- a/src/mp4track.cpp
+++ b/src/mp4track.cpp
@@ -908,16 +908,16 @@ File* MP4Track::GetSampleFile( MP4SampleId sampleId )
        MP4FtypAtom *pFtypAtom = reinterpret_cast<MP4FtypAtom *>( m_File.FindAtom( "ftyp" ) );
 
        // MOV spec does not require "ftyp" atom...
-       if ( pFtypAtom == nullptr )
+       if ( pFtypAtom == NULL )
        {
-          return nullptr;
+          return NULL;
        }
        else
        {
           // ... but most often it is present with a "qt  " value
           const char *majorBrand = pFtypAtom->majorBrand.GetValue();
           if ( ::strcmp( pFtypAtom->majorBrand.GetValue(), "qt  " ) == 0 )
-             return nullptr;
+             return NULL;
        }
        throw new Exception( "invalid stsd entry", __FILE__, __LINE__, __FUNCTION__ );
     }


### PR DESCRIPTION
Commit 15ec11166ba9ee7b77631d0d9234522f656cfd66 added code that uses `nullptr`. `nullptr` is C++11, it will break the build with gcc < 5.

Semantically, `NULL` and `nullptr` are different, so should not be mixed. In this situation, `m_File.FindAtom()` indeed does not return `nullptr`, but `NULL` (on error, that is).

Switch back to comparing against `NULL`.

Fixes:
 - http://autobuild.buildroot.org/results/14937c96a82fb3d10e5d83bd7b2905b846fb09f9

[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/mp4v2/0002-src-mp4track.cpp-replace-nullptr-by-NULL.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>