### PR TITLE
Remove exception location information in release builds.

### DIFF
--- a/libplatform/io/FileSystem_win32.cpp
+++ b/libplatform/io/FileSystem_win32.cpp
@@ -32,7 +32,7 @@ getAttributes ( string  path_ )
         // the places it's called.
         ostringstream msg;
         msg << "can't convert file to UTF-16(" << filename.utf8 << ")";
-        throw new Exception(msg.str(),__FILE__,__LINE__,__FUNCTION__);
+        throw new EXCEPTION(msg.str());
     }
 
     DWORD attributes = ::GetFileAttributesW(filename);
@@ -49,7 +49,7 @@ getAttributes ( string  path_ )
         // Anything else is an error
         ostringstream msg;
         msg << "GetFileAttributes(" << filename.utf8 << ") failed (" << last_err << ")";
-        throw new Exception(msg.str(),__FILE__,__LINE__,__FUNCTION__);
+        throw new EXCEPTION(msg.str());
     }
 
     // path exists so return its attributes

--- a/libutil/TrackModifier.cpp
+++ b/libutil/TrackModifier.cpp
@@ -143,7 +143,7 @@ TrackModifier::fromString( const string& src, bool& dst )
         if( iss.rdstate() != ios::eofbit ) {
             ostringstream oss;
             oss << "invalid value: " << src;
-            throw new Exception( oss.str(), __FILE__, __LINE__, __FUNCTION__ );
+            throw new EXCEPTION(oss.str());
         }
     }
 
@@ -160,7 +160,7 @@ TrackModifier::fromString( const string& src, float& dst )
     if( iss.rdstate() != ios::eofbit ) {
         ostringstream oss;
         oss << "invalid value: " << src;
-        throw new Exception( oss.str(), __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION(oss.str());
     }
 
     return dst;
@@ -176,7 +176,7 @@ TrackModifier::fromString( const string& src, uint16_t& dst )
     if( iss.rdstate() != ios::eofbit ) { 
         ostringstream oss;
         oss << "invalid value: " << src;
-        throw new Exception( oss.str(), __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION(oss.str());
     }   
 
     return dst;
@@ -203,7 +203,7 @@ TrackModifier::refTrackAtom( MP4File& file, uint16_t index )
     if( !trak ) {
         oss.str( "" );
         oss << "trackIndex " << index << " not found";
-        throw new Exception( oss.str(), __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION(oss.str());
     }
 
     return *trak;
@@ -474,7 +474,7 @@ TrackModifier::Properties::refProperty( const char* name )
     if( !_trackModifier._track.FindProperty( name, &property )) {
         ostringstream oss;
         oss << "trackId " << _trackModifier.trackId << " property '" << name << "' not found";
-        throw new Exception( oss.str(), __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION(oss.str());
     }
 
     return *property;

--- a/src/3gp.cpp
+++ b/src/3gp.cpp
@@ -41,7 +41,7 @@ void MP4File::Make3GPCompliant(const char* fileName,  char* majorBrand, uint32_t
 
     if (majorBrand) {
         if (!supportedBrands || !supportedBrandsCount) {
-            throw new Exception("Invalid parameters",  __FILE__, __LINE__, __FUNCTION__);
+            throw new EXCEPTION("Invalid parameters");
         }
     }
 

--- a/src/exception.cpp
+++ b/src/exception.cpp
@@ -29,6 +29,14 @@ namespace mp4v2 { namespace impl {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+Exception::Exception( const string& what_ )
+    : what(what_)
+    , line(0)
+{
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
 Exception::Exception( const string&     what_,
                       const char        *file_,
                       int               line_,
@@ -55,9 +63,24 @@ Exception::msg() const
 {
     ostringstream retval;
 
-    retval << function << ": " << what << " (" << file << "," << line << ")";
+    if( !function.empty() )
+        retval << function << ": ";
+
+    retval << what;
+    
+    if( !file.empty() )
+        retval << " (" << file << "," << line << ")";
 
     return retval.str();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+PlatformException::PlatformException( const string& what_,
+                                      int           errno_ )
+    : Exception(what_)
+    , m_errno(errno_)
+{
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -85,8 +108,13 @@ PlatformException::msg() const
 {
     ostringstream retval;
 
-    retval << function << ": " << what << ": errno: " << m_errno << " (" <<
-        file << "," << line << ")";
+    if( !function.empty() )
+        retval << function << ": ";
+
+    retval << what << ": errno: " << m_errno;
+    
+    if( !file.empty() )
+        retval << " (" << file << "," << line << ")";
 
     return retval.str();
 }

--- a/src/exception.h
+++ b/src/exception.h
@@ -29,9 +29,18 @@ namespace mp4v2 { namespace impl {
 
 ///////////////////////////////////////////////////////////////////////////////
 
+#ifdef NDEBUG
+#define EXCEPTION(message) mp4v2::impl::Exception(message)
+#define PLATFORM_EXCEPTION(message, errno) mp4v2::impl::PlatformException(message, errno)
+#else
+#define EXCEPTION(message) mp4v2::impl::Exception(message, __FILE__, __LINE__, __FUNCTION__)
+#define PLATFORM_EXCEPTION(message, errno) mp4v2::impl::PlatformException(message, errno, __FILE__, __LINE__, __FUNCTION__)
+#endif
+
 class MP4V2_EXPORT Exception
 {
 public:
+    explicit Exception( const string&   what_ );
     explicit Exception( const string&   what_,
                         const char      *file_,
                         int             line_,
@@ -50,6 +59,8 @@ public:
 class MP4V2_EXPORT PlatformException : public Exception
 {
 public:
+    explicit PlatformException( const string&   what_,
+                                int             errno_ );
     explicit PlatformException( const string&   what_,
                                 int             errno_,
                                 const char      *file_,

--- a/src/isma.cpp
+++ b/src/isma.cpp
@@ -40,7 +40,9 @@ static const uint8_t BifsV2Config[3] = {
 
 void MP4File::MakeIsmaCompliant(bool addIsmaComplianceSdp)
 {
-    ProtectWriteOperation(__FILE__, __LINE__, __FUNCTION__);
+    if( !IsWriteMode() ) {
+        throw new EXCEPTION("operation not permitted in read mode");
+    }
 
     if (m_useIsma) {
         // already done

--- a/src/mp4array.h
+++ b/src/mp4array.h
@@ -74,7 +74,7 @@ protected:
         \
         void Insert(type newElement, MP4ArrayIndex newIndex) { \
             if (newIndex > m_numElements) { \
-                  throw new PlatformException("illegal array index", ERANGE, __FILE__, __LINE__, __FUNCTION__); \
+                  throw new PLATFORM_EXCEPTION("illegal array index", ERANGE); \
             } \
             if (m_numElements == m_maxNumElements) { \
                 m_maxNumElements = max(m_maxNumElements, (MP4ArrayIndex)1) * 2; \
@@ -91,7 +91,7 @@ protected:
             if (!ValidIndex(index)) { \
                 ostringstream msg; \
                 msg << "illegal array index: " << index << " of " << m_numElements; \
-                throw new PlatformException(msg.str().c_str(), ERANGE, __FILE__, __LINE__, __FUNCTION__); \
+                throw new PLATFORM_EXCEPTION(msg.str().c_str(), ERANGE); \
             } \
             m_numElements--; \
             if (index < m_numElements) { \
@@ -103,7 +103,7 @@ protected:
             m_numElements = newSize; \
             m_maxNumElements = newSize; \
             if ( (uint64_t) m_maxNumElements * sizeof(type) > 0xFFFFFFFF ) \
-               throw new PlatformException("requested array size exceeds 4GB", ERANGE, __FILE__, __LINE__, __FUNCTION__); /* prevent overflow */ \
+               throw new PLATFORM_EXCEPTION("requested array size exceeds 4GB", ERANGE); /* prevent overflow */ \
             m_elements = (type*)MP4Realloc(m_elements, \
                 m_maxNumElements * sizeof(type)); \
         } \
@@ -115,7 +115,7 @@ protected:
             else { \
                 ostringstream msg; \
                 msg << "illegal array index: " << index << " of " << m_numElements; \
-                throw new PlatformException(msg.str().c_str(), ERANGE, __FILE__, __LINE__, __FUNCTION__ ); \
+                throw new PLATFORM_EXCEPTION(msg.str().c_str(), ERANGE); \
             } \
         } \
         \

--- a/src/mp4atom.cpp
+++ b/src/mp4atom.cpp
@@ -148,7 +148,7 @@ MP4Atom* MP4Atom::ReadAtom(MP4File& file, MP4Atom* pParentAtom)
        ostringstream oss;
        oss << "Invalid atom size in '" << type << "' atom, dataSize = " << dataSize << " cannot be less than hdrSize = " << static_cast<unsigned>( hdrSize );
        log.errorf( "%s: \"%s\": %s", __FUNCTION__, file.GetFilename().c_str(), oss.str().c_str() );
-       throw new Exception( oss.str().c_str(), __FILE__, __LINE__, __FUNCTION__ );
+       throw new EXCEPTION(oss.str().c_str());
     }
     dataSize -= hdrSize;
 
@@ -396,7 +396,7 @@ void MP4Atom::ReadProperties(uint32_t startIndex, uint32_t count)
 
             ostringstream oss;
             oss << "atom '" << GetType() << "' is too small; overrun at property: " << m_pProperties[i]->GetName();
-            throw new Exception( oss.str().c_str(), __FILE__, __LINE__, __FUNCTION__ );
+            throw new EXCEPTION(oss.str().c_str());
         }
 
         MP4LogLevel thisVerbosity =

--- a/src/mp4container.cpp
+++ b/src/mp4container.cpp
@@ -60,7 +60,7 @@ void MP4Container::FindIntegerProperty(const char* name,
                                        MP4Property** ppProperty, uint32_t* pIndex)
 {
     if (!FindProperty(name, ppProperty, pIndex)) {
-        throw new Exception("no such property", __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("no such property");
     }
 
     switch ((*ppProperty)->GetType()) {
@@ -71,7 +71,7 @@ void MP4Container::FindIntegerProperty(const char* name,
     case Integer64Property:
         break;
     default:
-        throw new Exception("type mismatch", __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("type mismatch");
     }
 }
 
@@ -99,10 +99,10 @@ void MP4Container::FindFloatProperty(const char* name,
                                      MP4Property** ppProperty, uint32_t* pIndex)
 {
     if (!FindProperty(name, ppProperty, pIndex)) {
-        throw new Exception("no such property", __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("no such property");
     }
     if ((*ppProperty)->GetType() != Float32Property) {
-        throw new Exception("type mismatch", __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("type mismatch");
     }
 }
 
@@ -130,10 +130,10 @@ void MP4Container::FindStringProperty(const char* name,
                                       MP4Property** ppProperty, uint32_t* pIndex)
 {
     if (!FindProperty(name, ppProperty, pIndex)) {
-        throw new Exception("no such property", __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("no such property");
     }
     if ((*ppProperty)->GetType() != StringProperty) {
-        throw new Exception("type mismatch", __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("type mismatch");
     }
 }
 
@@ -161,10 +161,10 @@ void MP4Container::FindBytesProperty(const char* name,
                                      MP4Property** ppProperty, uint32_t* pIndex)
 {
     if (!FindProperty(name, ppProperty, pIndex)) {
-        throw new Exception("no such property", __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("no such property");
     }
     if ((*ppProperty)->GetType() != BytesProperty) {
-        throw new Exception("type mismatch", __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("type mismatch");
     }
 }
 

--- a/src/mp4descriptor.cpp
+++ b/src/mp4descriptor.cpp
@@ -137,7 +137,7 @@ void MP4Descriptor::ReadProperties(MP4File& file,
             } else {
                 log.errorf("%s: \"%s\": Overran descriptor, tag %u data size %u property %u",
                            __FUNCTION__, file.GetFilename().c_str(), m_tag, m_size, i);
-                throw new Exception("overran descriptor",__FILE__, __LINE__, __FUNCTION__);
+                throw new EXCEPTION("overran descriptor");
             }
         }
     }

--- a/src/mp4file.h
+++ b/src/mp4file.h
@@ -877,8 +877,6 @@ protected:
 
     void Rename(const char* existingFileName, const char* newFileName);
 
-    void ProtectWriteOperation(const char* file, int line, const char *func);
-
     void FindIntegerProperty(const char* name,
                              MP4Property** ppProperty, uint32_t* pIndex = NULL);
     void FindFloatProperty(const char* name,

--- a/src/mp4file_io.cpp
+++ b/src/mp4file_io.cpp
@@ -44,7 +44,7 @@ void MP4File::SetPosition( uint64_t pos, File* file )
 {
     if( m_memoryBuffer ) {
         if( pos >= m_memoryBufferSize )
-            throw new Exception( "position out of range", __FILE__, __LINE__, __FUNCTION__ );
+            throw new EXCEPTION("position out of range");
         m_memoryBufferPosition = pos;
         return;
     }
@@ -54,7 +54,7 @@ void MP4File::SetPosition( uint64_t pos, File* file )
 
     ASSERT( file );
     if( file->seek( pos ))
-        throw new PlatformException( "seek failed", sys::getLastError(), __FILE__, __LINE__, __FUNCTION__ );
+        throw new PLATFORM_EXCEPTION("seek failed", sys::getLastError());
 }
 
 uint64_t MP4File::GetSize( File* file )
@@ -79,7 +79,7 @@ void MP4File::ReadBytes( uint8_t* buf, uint32_t bufsiz, File* file )
 
     if( m_memoryBuffer ) {
         if( m_memoryBufferPosition + bufsiz > m_memoryBufferSize )
-            throw new Exception( "not enough bytes, reached end-of-memory", __FILE__, __LINE__, __FUNCTION__ );
+            throw new EXCEPTION("not enough bytes, reached end-of-memory");
         memcpy( buf, &m_memoryBuffer[m_memoryBufferPosition], bufsiz );
         m_memoryBufferPosition += bufsiz;
         return;
@@ -91,9 +91,9 @@ void MP4File::ReadBytes( uint8_t* buf, uint32_t bufsiz, File* file )
     ASSERT( file );
     File::Size nin;
     if( file->read( buf, bufsiz, nin ))
-        throw new PlatformException( "read failed", sys::getLastError(), __FILE__, __LINE__, __FUNCTION__ );
+        throw new PLATFORM_EXCEPTION("read failed", sys::getLastError());
     if( nin != bufsiz )
-        throw new Exception( "not enough bytes, reached end-of-file", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("not enough bytes, reached end-of-file");
 }
 
 void MP4File::PeekBytes( uint8_t* buf, uint32_t bufsiz, File* file )
@@ -160,9 +160,9 @@ void MP4File::WriteBytes( uint8_t* buf, uint32_t bufsiz, File* file )
     ASSERT( file );
     File::Size nout;
     if( file->write( buf, bufsiz, nout ))
-        throw new PlatformException( "write failed", sys::getLastError(), __FILE__, __LINE__, __FUNCTION__ );
+        throw new PLATFORM_EXCEPTION("write failed", sys::getLastError());
     if( nout != bufsiz )
-        throw new Exception( "not all bytes written", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("not all bytes written");
 }
 
 uint64_t MP4File::ReadUInt(uint8_t size)
@@ -283,7 +283,7 @@ void MP4File::WriteFixed16(float value)
     if (value >= 0x100) {
         ostringstream msg;
         msg << value << " out of range";
-        throw new PlatformException(msg.str().c_str(), ERANGE, __FILE__, __LINE__, __FUNCTION__);
+        throw new PLATFORM_EXCEPTION(msg.str().c_str(), ERANGE);
     }
 
     uint8_t iPart = (uint8_t)value;
@@ -306,7 +306,7 @@ void MP4File::WriteFixed32(float value)
     if (value >= 0x10000) {
         ostringstream msg;
         msg << value << " out of range";
-        throw new PlatformException(msg.str().c_str(), ERANGE, __FILE__, __LINE__, __FUNCTION__);
+        throw new PLATFORM_EXCEPTION(msg.str().c_str(), ERANGE);
     }
 
     uint16_t iPart = (uint16_t)value;
@@ -380,8 +380,7 @@ char* MP4File::ReadCountedString(uint8_t charSize, bool allowExpandedCount, uint
             charLength += b;
             ix++;
             if (ix > 25)
-                throw new PlatformException("Counted string too long 25 * 255",ERANGE,
-                                            __FILE__, __LINE__, __FUNCTION__);
+                throw new PLATFORM_EXCEPTION("Counted string too long 25 * 255", ERANGE);
         } while (b == 255);
     } else {
         charLength = ReadUInt8();
@@ -450,7 +449,7 @@ void MP4File::WriteCountedString(char* string,
         if (charLength > 255) {
             ostringstream msg;
             msg << "Length is " << charLength;
-            throw new PlatformException(msg.str().c_str(), ERANGE, __FILE__, __LINE__, __FUNCTION__);
+            throw new PLATFORM_EXCEPTION(msg.str().c_str(), ERANGE);
         }
         // Write the count
         WriteUInt8(charLength);
@@ -545,7 +544,7 @@ void MP4File::WriteMpegLength(uint32_t value, bool compact)
     if (value > 0x0FFFFFFF) {
         ostringstream msg;
         msg << "out of range: " << value;
-        throw new PlatformException(msg.str().c_str(), ERANGE, __FILE__, __LINE__, __FUNCTION__ ); 
+        throw new PLATFORM_EXCEPTION(msg.str().c_str(), ERANGE); 
     }
 
     int8_t numBytes;

--- a/src/mp4property.cpp
+++ b/src/mp4property.cpp
@@ -355,7 +355,7 @@ void MP4StringProperty::SetValue(const char* value, uint32_t index)
     if (m_readOnly) {
         ostringstream msg;
         msg << "property " << m_name << "is read-only";
-        throw new PlatformException(msg.str().c_str(), EACCES, __FILE__, __LINE__, __FUNCTION__ );
+        throw new PLATFORM_EXCEPTION(msg.str().c_str(), EACCES);
     }
 
     MP4Free(m_values[index]);
@@ -525,13 +525,13 @@ void MP4BytesProperty::SetValue(const uint8_t* pValue, uint32_t valueSize,
     if (m_readOnly) {
         ostringstream msg;
         msg << "property " << m_name << "is read-only";
-        throw new PlatformException(msg.str().c_str(), EACCES, __FILE__, __LINE__, __FUNCTION__ );
+        throw new PLATFORM_EXCEPTION(msg.str().c_str(), EACCES);
     }
     if (m_fixedValueSize) {
         if (valueSize > m_fixedValueSize) {
             ostringstream msg;
             msg << GetParentAtom().GetType() << "." << GetName() << " value size " << valueSize << " exceeds fixed value size " << m_fixedValueSize;
-            throw new Exception(msg.str().c_str(), __FILE__, __LINE__, __FUNCTION__ );
+            throw new EXCEPTION(msg.str().c_str());
         }
         if (m_values[index] == NULL) {
             m_values[index] = (uint8_t*)MP4Calloc(m_fixedValueSize);
@@ -556,8 +556,7 @@ void MP4BytesProperty::SetValue(const uint8_t* pValue, uint32_t valueSize,
 void MP4BytesProperty::SetValueSize(uint32_t valueSize, uint32_t index)
 {
     if (m_fixedValueSize) {
-        throw new Exception("can't change size of fixed sized property",
-                            __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("can't change size of fixed sized property");
     }
     if (m_values[index] != NULL) {
         m_values[index] = (uint8_t*)MP4Realloc(m_values[index], valueSize);

--- a/src/mp4property.h
+++ b/src/mp4property.h
@@ -156,7 +156,7 @@ private:
             if (m_readOnly) { \
                 ostringstream msg; \
                 msg << "property is read-only: " << m_name; \
-                throw new PlatformException(msg.str().c_str(), EACCES, __FILE__, __LINE__, __FUNCTION__); \
+                throw new PLATFORM_EXCEPTION(msg.str().c_str(), EACCES); \
             } \
             m_values[index] = value; \
         } \
@@ -264,7 +264,7 @@ public:
         if (m_readOnly) {
             ostringstream msg;
             msg << "property is read-only: " << m_name;
-            throw new PlatformException(msg.str().c_str(), EACCES, __FILE__, __LINE__, __FUNCTION__);
+            throw new PLATFORM_EXCEPTION(msg.str().c_str(), EACCES);
         }
         m_values[index] = value;
     }

--- a/src/mp4track.cpp
+++ b/src/mp4track.cpp
@@ -232,7 +232,7 @@ MP4Track::MP4Track(MP4File& file, MP4Atom& trakAtom)
 
     // was everything found?
     if (!success) {
-        throw new Exception("invalid track", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("invalid track");
     }
     CalculateBytesPerSample();
 
@@ -277,7 +277,7 @@ void MP4Track::ReadSample(
     uint32_t*     dependencyFlags )
 {
     if( sampleId == MP4_INVALID_SAMPLE_ID )
-        throw new Exception( "sample id can't be zero", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("sample id can't be zero");
 
     if( hasDependencyFlags )
         *hasDependencyFlags = !m_sdtpLog.empty();
@@ -288,7 +288,7 @@ void MP4Track::ReadSample(
         }
         else {
             if( sampleId > m_sdtpLog.size() )
-                throw new Exception( "sample id > sdtp logsize", __FILE__, __LINE__, __FUNCTION__ );
+                throw new EXCEPTION("sample id > sdtp logsize");
             *dependencyFlags = m_sdtpLog[sampleId-1]; // sampleId is 1-based
         }
     }
@@ -301,14 +301,13 @@ void MP4Track::ReadSample(
 
     File* fin = GetSampleFile( sampleId );
     if( fin == (File*)-1 )
-        throw new Exception( "sample is located in an inaccessible file", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("sample is located in an inaccessible file");
 
     uint64_t fileOffset = GetSampleFileOffset(sampleId);
 
     uint32_t sampleSize = GetSampleSize(sampleId);
     if (*ppBytes != NULL && *pNumBytes < sampleSize) {
-        throw new Exception("sample buffer is too small",
-                            __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("sample buffer is too small");
     }
     *pNumBytes = sampleSize;
 
@@ -370,8 +369,7 @@ void MP4Track::ReadSampleFragment(
     uint8_t* pDest)
 {
     if (sampleId == MP4_INVALID_SAMPLE_ID) {
-        throw new Exception("invalid sample id",
-                            __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("invalid sample id");
     }
 
     if (sampleId != m_cachedReadSampleId) {
@@ -389,8 +387,7 @@ void MP4Track::ReadSampleFragment(
     }
 
     if (sampleOffset + sampleLength > m_cachedReadSampleSize) {
-        throw new Exception("offset and/or length are too large",
-                            __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("offset and/or length are too large");
     }
 
     memcpy(pDest, &m_pCachedReadSample[sampleOffset], sampleLength);
@@ -410,7 +407,7 @@ void MP4Track::WriteSample(
                   m_trackId, m_writeSampleId, numBytes, numBytes);
 
     if (pBytes == NULL && numBytes > 0) {
-        throw new Exception("no sample data", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("no sample data");
     }
 
     if (m_isAmr == AMR_UNINITIALIZED ) {
@@ -864,7 +861,7 @@ uint32_t MP4Track::GetSampleStscIndex(MP4SampleId sampleId)
     uint32_t numStscs = m_pStscCountProperty->GetValue();
 
     if (numStscs == 0) {
-        throw new Exception("No data chunks exist", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("No data chunks exist");
     }
 
     for (stscIndex = 0; stscIndex < numStscs; stscIndex++) {
@@ -919,7 +916,7 @@ File* MP4Track::GetSampleFile( MP4SampleId sampleId )
           if ( ::strcmp( pFtypAtom->majorBrand.GetValue(), "qt  " ) == 0 )
              return nullptr;
        }
-       throw new Exception( "invalid stsd entry", __FILE__, __LINE__, __FUNCTION__ );
+       throw new EXCEPTION("invalid stsd entry");
     }
 
     uint32_t drefIndex = pDrefIndexProperty->GetValue();
@@ -1114,8 +1111,7 @@ void MP4Track::GetSampleTimes(MP4SampleId sampleId,
         elapsed += sampleCount * sampleDelta;
     }
 
-    throw new Exception("sample id out of range",
-                        __FILE__, __LINE__, __FUNCTION__ );
+    throw new EXCEPTION("sample id out of range");
 }
 
 MP4SampleId MP4Track::GetSampleIdFromTime(
@@ -1155,8 +1151,7 @@ MP4SampleId MP4Track::GetSampleIdFromTime(
         elapsed += sampleCount * sampleDelta;
     }
 
-    throw new Exception("time out of range",
-                        __FILE__, __LINE__, __FUNCTION__);
+    throw new EXCEPTION("time out of range");
 
     return 0; // satisfy MS compiler
 }
@@ -1209,8 +1204,7 @@ uint32_t MP4Track::GetSampleCttsIndex(MP4SampleId sampleId,
         sid += sampleCount;
     }
 
-    throw new Exception("sample id out of range",
-                        __FILE__, __LINE__, __FUNCTION__ );
+    throw new EXCEPTION("sample id out of range");
     return 0; // satisfy MS compiler
 }
 
@@ -1704,14 +1698,12 @@ MP4EditId MP4Track::AddEdit(MP4EditId editId)
 void MP4Track::DeleteEdit(MP4EditId editId)
 {
     if (editId == MP4_INVALID_EDIT_ID) {
-        throw new Exception("edit id can't be zero",
-                            __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("edit id can't be zero");
     }
 
     if (!m_pElstCountProperty
             || m_pElstCountProperty->GetValue() == 0) {
-        throw new Exception("no edits exist",
-                            __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("no edits exist");
     }
 
     m_pElstMediaTimeProperty->DeleteValue(editId - 1);
@@ -1879,8 +1871,7 @@ MP4SampleId MP4Track::GetSampleIdFromEditTime(
             return sampleId;
         }
 
-        throw new Exception("time out of range",
-                            __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("time out of range");
 
     } else { // no edit list
         sampleId = GetSampleIdFromTime(editWhen, false);

--- a/src/mp4util.cpp
+++ b/src/mp4util.cpp
@@ -258,7 +258,7 @@ uint64_t MP4ConvertTime(uint64_t t,
 {
     // avoid float point exception
     if (oldTimeScale == 0) {
-        throw new Exception("division by zero", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("division by zero");
     }
 
     if (oldTimeScale == newTimeScale) return t;

--- a/src/mp4util.h
+++ b/src/mp4util.h
@@ -33,15 +33,22 @@ namespace mp4v2 { namespace impl {
 #ifndef ASSERT
 #   define ASSERT(expr) \
         if (!(expr)) { \
-            throw new Exception("assert failure: " LIBMPV42_STRINGIFY((expr)), __FILE__, __LINE__, __FUNCTION__ ); \
+            throw new EXCEPTION("assert failure: " LIBMPV42_STRINGIFY((expr))); \
         }
 #endif
 
-#define WARNING(expr) \
-    if (expr) { \
-        log.errorf("Warning (%s) in %s at line %u", \
-                         LIBMPV42_STRINGIFY(expr), __FILE__, __LINE__); \
-    }
+#ifdef NDEBUG
+#   define WARNING(expr) \
+        if (expr) { \
+            log.errorf("Warning: %s", LIBMPV42_STRINGIFY(expr)); \
+        }
+#else
+#   define WARNING(expr) \
+        if (expr) { \
+            log.errorf("Warning (%s) in %s at line %u", \
+                            LIBMPV42_STRINGIFY(expr), __FILE__, __LINE__); \
+        }
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 
@@ -55,7 +62,7 @@ inline void* MP4Malloc(size_t size) {
     if (size == 0) return NULL;
     void* p = malloc(size);
     if (p == NULL && size > 0) {
-        throw new PlatformException("malloc failed",errno,__FILE__,__LINE__,__FUNCTION__);
+        throw new PLATFORM_EXCEPTION("malloc failed", errno);
     }
     return p;
 }
@@ -79,7 +86,7 @@ inline void* MP4Realloc(void* p, uint32_t newSize) {
 
     void* temp = realloc(p, newSize);
     if (temp == NULL && newSize > 0) {
-        throw new PlatformException("malloc failed",errno,__FILE__,__LINE__,__FUNCTION__);
+        throw new PLATFORM_EXCEPTION("malloc failed", errno);
     }
     return temp;
 }

--- a/src/qtff/ColorParameterBox.cpp
+++ b/src/qtff/ColorParameterBox.cpp
@@ -41,14 +41,14 @@ ColorParameterBox::add( MP4FileHandle file, uint16_t trackIndex, const Item& ite
     MP4Atom* coding;
 
     if( !MP4_IS_VALID_FILE_HANDLE( file ))
-        throw new Exception( "invalid file handle", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("invalid file handle");
 
     if( findCoding( file, trackIndex, coding ))
-        throw new Exception( "supported coding not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("supported coding not found");
 
     MP4Atom* colr;
     if( !findColorParameterBox( file, *coding, colr ))
-        throw new Exception( "colr-box already exists", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("colr-box already exists");
 
     colr = MP4Atom::CreateAtom( *((MP4File *)file), coding, BOX_CODE.c_str() );
     coding->AddChildAtom( colr );
@@ -92,11 +92,11 @@ ColorParameterBox::get( MP4FileHandle file, uint16_t trackIndex, Item& item )
 
     MP4Atom* coding;
     if( findCoding( file, trackIndex, coding ))
-        throw new Exception( "supported coding not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("supported coding not found");
 
     MP4Atom* colr;
     if( findColorParameterBox( file, *coding, colr ))
-        throw new Exception( "colr-box not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("colr-box not found");
 
     MP4Integer16Property* primariesIndex;
     MP4Integer16Property* transferFunctionIndex;
@@ -171,11 +171,11 @@ ColorParameterBox::remove( MP4FileHandle file, uint16_t trackIndex )
 {
     MP4Atom* coding;
     if( findCoding( file, trackIndex, coding ))
-        throw new Exception( "supported coding not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("supported coding not found");
 
     MP4Atom* colr;
     if( findColorParameterBox( file, *coding, colr ))
-        throw new Exception( "colr-box not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("colr-box not found");
 
     coding->DeleteChildAtom( colr );
     delete colr;
@@ -199,11 +199,11 @@ ColorParameterBox::set( MP4FileHandle file, uint16_t trackIndex, const Item& ite
 {
     MP4Atom* coding;
     if( findCoding( file, trackIndex, coding ))
-        throw new Exception( "supported coding not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("supported coding not found");
 
     MP4Atom* colr;
     if( findColorParameterBox( file, *coding, colr ))
-        throw new Exception( "colr-box not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("colr-box not found");
 
     MP4Integer16Property* primariesIndex;
     MP4Integer16Property* transferFunctionIndex;
@@ -268,7 +268,7 @@ ColorParameterBox::Item::convertFromCSV( const string& text )
         xss << "invalid ColorParameterBox format"
             << " (expecting: INDEX1,INDEX2,INDEX3)"
             << " got: " << text;
-        throw new Exception( xss.str(), __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION(xss.str());
     }
 }
 

--- a/src/qtff/PictureAspectRatioBox.cpp
+++ b/src/qtff/PictureAspectRatioBox.cpp
@@ -41,14 +41,14 @@ PictureAspectRatioBox::add( MP4FileHandle file, uint16_t trackIndex, const Item&
     MP4Atom* coding;
 
     if( !MP4_IS_VALID_FILE_HANDLE( file ))
-        throw new Exception( "invalid file handle", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("invalid file handle");
 
     if( findCoding( file, trackIndex, coding ))
-        throw new Exception( "supported coding not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("supported coding not found");
 
     MP4Atom* pasp;
     if( !findPictureAspectRatioBox( file, *coding, pasp ))
-        throw new Exception( "pasp-box already exists", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("pasp-box already exists");
 
     pasp = MP4Atom::CreateAtom( *((MP4File *)file), coding, BOX_CODE.c_str() );
     coding->AddChildAtom( pasp );
@@ -84,11 +84,11 @@ PictureAspectRatioBox::get( MP4FileHandle file, uint16_t trackIndex, Item& item 
 
     MP4Atom* coding;
     if( findCoding( file, trackIndex, coding ))
-        throw new Exception( "supported coding not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("supported coding not found");
 
     MP4Atom* pasp;
     if( findPictureAspectRatioBox( file, *coding, pasp ))
-        throw new Exception( "pasp-box not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("pasp-box not found");
 
     MP4Integer16Property* hSpacing;
     MP4Integer16Property* vSpacing;
@@ -159,11 +159,11 @@ PictureAspectRatioBox::remove( MP4FileHandle file, uint16_t trackIndex )
 {
     MP4Atom* coding;
     if( findCoding( file, trackIndex, coding ))
-        throw new Exception( "supported coding not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("supported coding not found");
 
     MP4Atom* pasp;
     if( findPictureAspectRatioBox( file, *coding, pasp ))
-        throw new Exception( "pasp-box not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("pasp-box not found");
 
     coding->DeleteChildAtom( pasp );
     delete pasp;
@@ -187,11 +187,11 @@ PictureAspectRatioBox::set( MP4FileHandle file, uint16_t trackIndex, const Item&
 {
     MP4Atom* coding;
     if( findCoding( file, trackIndex, coding ))
-        throw new Exception( "supported coding not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("supported coding not found");
 
     MP4Atom* pasp;
     if( findPictureAspectRatioBox( file, *coding, pasp ))
-        throw new Exception( "pasp-box not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("pasp-box not found");
 
     MP4Integer16Property* hSpacing;
     MP4Integer16Property* vSpacing;
@@ -258,7 +258,7 @@ PictureAspectRatioBox::Item::convertFromCSV( const string& text )
         xss << "invalid PcitureAspectRatioBox format"
             << " (expecting: hSpacing,vSpacing)"
             << " got: " << text;
-        throw new Exception( xss.str(), __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION(xss.str());
     }
 }
 

--- a/src/qtff/coding.cpp
+++ b/src/qtff/coding.cpp
@@ -54,29 +54,29 @@ findCoding( MP4FileHandle file, uint16_t trackIndex, MP4Atom*& coding )
     if( trackIndex == numeric_limits<uint16_t>::max() ) {
         ostringstream xss;
         xss << "invalid track-index: " << trackIndex;
-        throw new Exception( xss.str(), __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION(xss.str());
     }
 
     ostringstream oss;
     oss << "moov.trak[" << trackIndex << "].mdia.hdlr";
     MP4Atom* hdlr = mp4.FindAtom( oss.str().c_str() );
     if( !hdlr )
-        throw new Exception( "media handler not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("media handler not found");
 
     MP4StringProperty* handlerType;
     if( !hdlr->FindProperty( "hdlr.handlerType", (MP4Property**)&handlerType ))
-        throw new Exception( "media handler type-property not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("media handler type-property not found");
 
     const string video = "vide";
     if( video != handlerType->GetValue() )
-        throw new Exception( "video-track required", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("video-track required");
 
     oss.str( "" );
     oss.clear();
     oss << "moov.trak[" << trackIndex << "].mdia.minf.stbl.stsd";
     MP4Atom* stsd = mp4.FindAtom( oss.str().c_str() );
     if( !stsd )
-        throw new Exception( "media handler type-property not found", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("media handler type-property not found");
 
     // find first atom which is a supported coding
     const uint32_t atomc = stsd->GetNumberOfChildAtoms();

--- a/src/rtphint.cpp
+++ b/src/rtphint.cpp
@@ -148,8 +148,7 @@ void MP4RtpHintTrack::ReadHint(
 uint16_t MP4RtpHintTrack::GetHintNumberOfPackets()
 {
     if (m_pReadHint == NULL) {
-        throw new Exception("no hint has been read",
-                            __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("no hint has been read");
     }
     return m_pReadHint->GetNumberOfPackets();
 }
@@ -157,8 +156,7 @@ uint16_t MP4RtpHintTrack::GetHintNumberOfPackets()
 bool MP4RtpHintTrack::GetPacketBFrame(uint16_t packetIndex)
 {
     if (m_pReadHint == NULL) {
-        throw new Exception("no hint has been read",
-                            __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("no hint has been read");
     }
     MP4RtpPacket* pPacket =
         m_pReadHint->GetPacket(packetIndex);
@@ -169,8 +167,7 @@ bool MP4RtpHintTrack::GetPacketBFrame(uint16_t packetIndex)
 uint16_t MP4RtpHintTrack::GetPacketTransmitOffset(uint16_t packetIndex)
 {
     if (m_pReadHint == NULL) {
-        throw new Exception("no hint has been read",
-                            __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("no hint has been read");
      }
 
     MP4RtpPacket* pPacket =
@@ -188,12 +185,10 @@ void MP4RtpHintTrack::ReadPacket(
     bool addPayload)
 {
     if (m_pReadHint == NULL) {
-        throw new Exception("no hint has been read",
-                            __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("no hint has been read");
     }
     if (!addHeader && !addPayload) {
-        throw new Exception("no data requested",
-                             __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("no data requested");
     }
 
     MP4RtpPacket* pPacket =
@@ -458,7 +453,7 @@ void MP4RtpHintTrack::AddHint(bool isBFrame, uint32_t timestampOffset)
     }
 
     if (m_pWriteHint) {
-        throw new Exception("unwritten hint is still pending", __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("unwritten hint is still pending");
     }
 
     m_pWriteHint = new MP4RtpHint(*this);
@@ -472,7 +467,7 @@ void MP4RtpHintTrack::AddHint(bool isBFrame, uint32_t timestampOffset)
 void MP4RtpHintTrack::AddPacket(bool setMbit, int32_t transmitOffset)
 {
     if (m_pWriteHint == NULL) {
-        throw new Exception("no hint pending", __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("no hint pending");
     }
 
     MP4RtpPacket* pPacket = m_pWriteHint->AddPacket();
@@ -499,21 +494,19 @@ void MP4RtpHintTrack::AddImmediateData(
     uint32_t numBytes)
 {
     if (m_pWriteHint == NULL) {
-        throw new Exception("no hint pending", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("no hint pending");
     }
 
     MP4RtpPacket* pPacket = m_pWriteHint->GetCurrentPacket();
     if (pPacket == NULL) {
-        throw new Exception("no packet pending", __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("no packet pending");
     }
 
     if (pBytes == NULL || numBytes == 0) {
-        throw new Exception("no data",
-                            __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("no data");
     }
     if (numBytes > 14) {
-        throw new Exception("data size is larger than 14 bytes",
-                            __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("data size is larger than 14 bytes");
     }
 
     MP4RtpImmediateData* pData = new MP4RtpImmediateData(*pPacket);
@@ -534,12 +527,12 @@ void MP4RtpHintTrack::AddSampleData(
     uint32_t dataLength)
 {
     if (m_pWriteHint == NULL) {
-        throw new Exception("no hint pending", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("no hint pending");
     }
 
     MP4RtpPacket* pPacket = m_pWriteHint->GetCurrentPacket();
     if (pPacket == NULL) {
-        throw new Exception("no packet pending", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("no packet pending");
     }
 
     MP4RtpSampleData* pData = new MP4RtpSampleData(*pPacket);
@@ -558,7 +551,7 @@ void MP4RtpHintTrack::AddSampleData(
 void MP4RtpHintTrack::AddESConfigurationPacket()
 {
     if (m_pWriteHint == NULL) {
-        throw new Exception("no hint pending", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("no hint pending");
     }
 
     uint8_t* pConfig = NULL;
@@ -574,7 +567,7 @@ void MP4RtpHintTrack::AddESConfigurationPacket()
     ASSERT(m_pMaxPacketSizeProperty);
 
     if (configSize > m_pMaxPacketSizeProperty->GetValue()) {
-        throw new Exception("ES configuration is too large for RTP payload", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("ES configuration is too large for RTP payload");
     }
 
     AddPacket(false);
@@ -603,7 +596,7 @@ void MP4RtpHintTrack::AddESConfigurationPacket()
 void MP4RtpHintTrack::WriteHint(MP4Duration duration, bool isSyncSample)
 {
     if (m_pWriteHint == NULL) {
-        throw new Exception("no hint pending", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("no hint pending");
     }
 
     uint8_t* pBytes;
@@ -894,7 +887,7 @@ void MP4RtpPacket::Read(MP4File& file)
             pData = new MP4RtpSampleDescriptionData(*this);
             break;
         default:
-            throw new Exception("unknown packet data entry type", __FILE__, __LINE__, __FUNCTION__ );
+            throw new EXCEPTION("unknown packet data entry type");
         }
 
         m_rtpData.Add(pData);
@@ -911,7 +904,7 @@ void MP4RtpPacket::ReadExtra(MP4File& file)
     int32_t extraLength = (int32_t)file.ReadUInt32();
 
     if (extraLength < 4) {
-        throw new Exception("bad packet extra info length", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("bad packet extra info length");
     }
     extraLength -= 4;
 
@@ -920,7 +913,7 @@ void MP4RtpPacket::ReadExtra(MP4File& file)
         uint32_t entryTag = file.ReadUInt32();
 
         if (entryLength < 8) {
-            throw new Exception("bad packet extra info entry length", __FILE__, __LINE__, __FUNCTION__ );
+            throw new EXCEPTION("bad packet extra info entry length");
         }
 
         if (entryTag == STRTOINT32("rtpo") && entryLength == 12) {
@@ -935,7 +928,7 @@ void MP4RtpPacket::ReadExtra(MP4File& file)
     }
 
     if (extraLength < 0) {
-        throw new Exception("invalid packet extra info length", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("invalid packet extra info length");
     }
 }
 
@@ -1318,7 +1311,7 @@ void MP4RtpSampleDescriptionData::GetData(uint8_t* pDest)
 
     // bad reference
     if (pSdAtom == NULL) {
-        throw new Exception("invalid sample description index", __FILE__, __LINE__, __FUNCTION__ );
+        throw new EXCEPTION("invalid sample description index");
     }
 
     // check validity of the upcoming copy
@@ -1328,8 +1321,7 @@ void MP4RtpSampleDescriptionData::GetData(uint8_t* pDest)
         ((MP4Integer32Property*)m_pProperties[4])->GetValue();
 
     if (offset + length > pSdAtom->GetSize()) {
-        throw new Exception("offset and/or length are too large",
-                            __FILE__, __LINE__, __FUNCTION__);
+        throw new EXCEPTION("offset and/or length are too large");
     }
 
     // now we use the raw file to get the desired bytes


### PR DESCRIPTION
Currently the `__FILE__`, `__LINE__` and `__FUNCTION__` macros are used in every exception instantiation to provide information about where an exception occurred. Especially the usage of the `__FILE__` macro is problematic as it fills up the compiled binary with a large amount of strings containing absolute paths to source files.

This proposed change here wraps exception instantiation in a macro to better control the usage of the `__FILE__` macro. It is now only enabled in debug builds to ensure that no filename strings are included in release binaries.