### PR TITLE
Fix out-of-range if first sample is not sync

### DIFF
--- a/src/mp4track.cpp
+++ b/src/mp4track.cpp
@@ -1400,6 +1400,9 @@ bool MP4Track::IsSyncSample(MP4SampleId sampleId)
             return true;
         }
 
+        if (stssLIndex == stssRIndex)
+            break;
+
         if (sampleId > syncSampleId) {
             stssLIndex = stssIndex + 1;
         } else {


### PR DESCRIPTION
mp4track output of first 3 samples of offending file without fix:

operator[]: illegal array index: 2147483647 of 4: errno: 34 (../mp4v2/src/mp4array.h,130)
sampleId      1, size    27 duration     2939 time        0 00:00:00.000  
sampleId      2, size 24361 duration     5041 time     2939 00:00:00.032 S
sampleId      3, size 19542 duration     2880 time     7980 00:00:00.088 

mp4track output of first 3 samples of offending file with fix:

sampleId      1, size    27 duration     2939 time        0 00:00:00.000  
sampleId      2, size 24361 duration     5041 time     2939 00:00:00.032 S
sampleId      3, size 19542 duration     2880 time     7980 00:00:00.088  

The video in question was created by a Sony Xperia L1 model g3311.

Note: I can't provide the file because of privacy reasons (it came from a customer).