### PR TITLE
mp4v2 security fixes

### DIFF
--- a/src/atom_ftyp.cpp
+++ b/src/atom_ftyp.cpp
@@ -53,6 +53,9 @@ void MP4FtypAtom::Generate()
 
 void MP4FtypAtom::Read()
 {
+   if ( m_size == 0ULL )
+      return;
+
     compatibleBrands.SetCount( (m_size - 8) / 4 ); // brands array fills rest of atom
     MP4Atom::Read();
 }

--- a/src/atoms.h
+++ b/src/atoms.h
@@ -491,9 +491,9 @@ public:
     // number of bytes == stsz.sampleCount.
     MP4BytesProperty& data;
 private:
-    MP4SdtpAtom();
-    MP4SdtpAtom( const MP4SdtpAtom &src );
-    MP4SdtpAtom &operator= ( const MP4SdtpAtom &src );
+    MP4SdtpAtom() = delete;
+    MP4SdtpAtom( const MP4SdtpAtom& src ) = delete;
+    MP4SdtpAtom& operator=( const MP4SdtpAtom& src ) = delete;
 };
 
 class MP4SmiAtom : public MP4Atom {

--- a/src/mp4atom.cpp
+++ b/src/mp4atom.cpp
@@ -395,7 +395,15 @@ void MP4Atom::ReadProperties(uint32_t startIndex, uint32_t count)
                           m_File.GetPosition(), m_end);
 
             ostringstream oss;
-            oss << "atom '" << GetType() << "' is too small; overrun at property: " << m_pProperties[i]->GetName();
+            const char* propName = nullptr;
+            auto prop = m_pProperties[i];
+            if ( prop != nullptr )
+               propName = prop->GetName();
+            if ( propName != nullptr )
+               oss << "atom '" << GetType() << "' is too small; overrun at property: " << propName;
+            else
+               oss << "atom '" << GetType() << "' is too small; overrun reading property";
+
             throw new Exception( oss.str().c_str(), __FILE__, __LINE__, __FUNCTION__ );
         }
 

--- a/src/mp4track.cpp
+++ b/src/mp4track.cpp
@@ -237,13 +237,15 @@ MP4Track::MP4Track(MP4File& file, MP4Atom& trakAtom)
     CalculateBytesPerSample();
 
     // update sdtp log from sdtp atom
-    MP4SdtpAtom* sdtp = (MP4SdtpAtom*)m_trakAtom.FindAtom( "trak.mdia.minf.stbl.sdtp" );
-    if( sdtp ) {
-        uint8_t* buffer;
-        uint32_t bufsize;
-        sdtp->data.GetValue( &buffer, &bufsize );
-        m_sdtpLog.assign( (char*)buffer, bufsize );
-        free( buffer );
+    MP4Atom* atom = m_trakAtom.FindAtom( "trak.mdia.minf.stbl.sdtp" );
+    MP4SdtpAtom* sdtp = dynamic_cast<MP4SdtpAtom *>( atom );  
+    if ( sdtp != nullptr )
+    {
+       uint8_t* buffer;
+       uint32_t bufsize;
+       sdtp->data.GetValue( &buffer, &bufsize );
+       m_sdtpLog.assign( (char*)buffer, bufsize );
+       free( buffer );
     }
 }
 


### PR DESCRIPTION
Fixes three crashes that can occur while reading malformed (potentially malicious) TREC or MP4 files.