### PR TITLE
Add more error checking around FTYP atom size

### DIFF
--- a/src/atom_ftyp.cpp
+++ b/src/atom_ftyp.cpp
@@ -53,7 +53,7 @@ void MP4FtypAtom::Generate()
 
 void MP4FtypAtom::Read()
 {
-   if ( m_size == 0ULL )
+   if ( m_size == 0ULL || m_size < 8ULL )
       return;
 
     compatibleBrands.SetCount( (m_size - 8) / 4 ); // brands array fills rest of atom


### PR DESCRIPTION
Fixes a crash that can occur while reading malformed (potentially malicious) TREC or MP4 files.