### PR TITLE
Remove some parse exceptions

### DIFF
--- a/src/mp4atom.cpp
+++ b/src/mp4atom.cpp
@@ -404,7 +404,7 @@ void MP4Atom::ReadProperties(uint32_t startIndex, uint32_t count)
             else
                oss << "atom '" << GetType() << "' is too small; overrun reading property";
 
-            throw new Exception( oss.str().c_str(), __FILE__, __LINE__, __FUNCTION__ );
+            log.verbose1f( "%s", oss.str().c_str() );
         }
 
         MP4LogLevel thisVerbosity =

--- a/src/mp4descriptor.cpp
+++ b/src/mp4descriptor.cpp
@@ -137,7 +137,6 @@ void MP4Descriptor::ReadProperties(MP4File& file,
             } else {
                 log.errorf("%s: \"%s\": Overran descriptor, tag %u data size %u property %u",
                            __FUNCTION__, file.GetFilename().c_str(), m_tag, m_size, i);
-                throw new Exception("overran descriptor",__FILE__, __LINE__, __FUNCTION__);
             }
         }
     }

--- a/src/mp4file.cpp
+++ b/src/mp4file.cpp
@@ -742,10 +742,11 @@ bool MP4File::FindProperty(const char* name,
 void MP4File::FindIntegerProperty(const char* name,
                                   MP4Property** ppProperty, uint32_t* pIndex)
 {
-    if (!FindProperty(name, ppProperty, pIndex)) {
+    if ( !FindProperty( name, ppProperty, pIndex ) ) {
         ostringstream msg;
         msg << "no such property - " << name;
-        throw new Exception(msg.str(), __FILE__, __LINE__, __FUNCTION__);
+        log.errorf( "MP4File::FindIntegerProperty - %s", msg.str().c_str() );
+        return;
     }
 
     switch ((*ppProperty)->GetType()) {
@@ -764,10 +765,12 @@ void MP4File::FindIntegerProperty(const char* name,
 
 uint64_t MP4File::GetIntegerProperty(const char* name)
 {
-    MP4Property* pProperty;
+    MP4Property* pProperty = nullptr;
     uint32_t index;
 
     FindIntegerProperty(name, &pProperty, &index);
+    if ( pProperty == nullptr )
+       return 0ULL;
 
     return ((MP4IntegerProperty*)pProperty)->GetValue(index);
 }
@@ -776,12 +779,13 @@ void MP4File::SetIntegerProperty(const char* name, uint64_t value)
 {
     ProtectWriteOperation(__FILE__, __LINE__, __FUNCTION__);
 
-    MP4Property* pProperty = NULL;
+    MP4Property* pProperty = nullptr;
     uint32_t index = 0;
 
     FindIntegerProperty(name, &pProperty, &index);
 
-    ((MP4IntegerProperty*)pProperty)->SetValue(value, index);
+    if ( pProperty != nullptr )
+      ((MP4IntegerProperty*)pProperty)->SetValue(value, index);
 }
 
 void MP4File::FindFloatProperty(const char* name,
@@ -790,35 +794,38 @@ void MP4File::FindFloatProperty(const char* name,
     if (!FindProperty(name, ppProperty, pIndex)) {
         ostringstream msg;
         msg << "no such property - " << name;
-        throw new Exception(msg.str(), __FILE__, __LINE__, __FUNCTION__);
+        log.errorf( "MP4File::FindFloatProperty - %s", msg.str().c_str() );
+        return;
     }
     if ((*ppProperty)->GetType() != Float32Property) {
         ostringstream msg;
         msg << "type mismatch - property " << name << " type " << (*ppProperty)->GetType();
-        throw new Exception(msg.str(), __FILE__, __LINE__, __FUNCTION__);
+        log.errorf( "MP4File::FindFloatProperty - %s", msg.str().c_str() );
+        return;
     }
 }
 
 float MP4File::GetFloatProperty(const char* name)
 {
-    MP4Property* pProperty;
-    uint32_t index;
+   MP4Property* pProperty = nullptr;
+   uint32_t index;
 
-    FindFloatProperty(name, &pProperty, &index);
+   FindFloatProperty(name, &pProperty, &index);
 
-    return ((MP4Float32Property*)pProperty)->GetValue(index);
+   return ( pProperty != nullptr ) ? ( (MP4Float32Property*)pProperty )->GetValue( index ) : 0.f;
 }
 
 void MP4File::SetFloatProperty(const char* name, float value)
 {
     ProtectWriteOperation(__FILE__, __LINE__, __FUNCTION__);
 
-    MP4Property* pProperty;
+    MP4Property* pProperty = nullptr;
     uint32_t index;
 
     FindFloatProperty(name, &pProperty, &index);
 
-    ((MP4Float32Property*)pProperty)->SetValue(value, index);
+    if ( pProperty != nullptr )
+      ((MP4Float32Property*)pProperty)->SetValue(value, index);
 }
 
 void MP4File::FindStringProperty(const char* name,
@@ -827,35 +834,38 @@ void MP4File::FindStringProperty(const char* name,
     if (!FindProperty(name, ppProperty, pIndex)) {
         ostringstream msg;
         msg << "no such property - " << name;
-        throw new Exception(msg.str(), __FILE__, __LINE__, __FUNCTION__);
+        log.errorf( "MP4File::FindStringProperty - %s", msg.str().c_str() );
+        return;
     }
     if ((*ppProperty)->GetType() != StringProperty) {
         ostringstream msg;
         msg << "type mismatch - property " << name << " type " << (*ppProperty)->GetType();
-        throw new Exception(msg.str(), __FILE__, __LINE__, __FUNCTION__);
+        log.errorf( "MP4File::FindStringProperty - %s", msg.str().c_str() );
+        return;
     }
 }
 
 const char* MP4File::GetStringProperty(const char* name)
 {
-    MP4Property* pProperty;
-    uint32_t index;
+   MP4Property* pProperty = nullptr;
+   uint32_t index;
 
-    FindStringProperty(name, &pProperty, &index);
+   FindStringProperty(name, &pProperty, &index);
 
-    return ((MP4StringProperty*)pProperty)->GetValue(index);
+   return ( pProperty != nullptr ) ? ( (MP4StringProperty*)pProperty )->GetValue( index ) : "";
 }
 
 void MP4File::SetStringProperty(const char* name, const char* value)
 {
     ProtectWriteOperation(__FILE__, __LINE__, __FUNCTION__);
 
-    MP4Property* pProperty;
+    MP4Property* pProperty = nullptr;
     uint32_t index;
 
     FindStringProperty(name, &pProperty, &index);
 
-    ((MP4StringProperty*)pProperty)->SetValue(value, index);
+    if ( pProperty != nullptr )
+      ((MP4StringProperty*)pProperty)->SetValue(value, index);
 }
 
 void MP4File::FindBytesProperty(const char* name,
@@ -864,24 +874,27 @@ void MP4File::FindBytesProperty(const char* name,
     if (!FindProperty(name, ppProperty, pIndex)) {
         ostringstream msg;
         msg << "no such property " << name;
-        throw new Exception(msg.str(), __FILE__, __LINE__, __FUNCTION__);
+        log.errorf( "MP4File::FindBytesProperty - %s", msg.str().c_str() );
+        return;
     }
     if ((*ppProperty)->GetType() != BytesProperty) {
         ostringstream msg;
         msg << "type mismatch - property " << name << " - type " <<  (*ppProperty)->GetType();
-        throw new Exception(msg.str(), __FILE__, __LINE__, __FUNCTION__);
+        log.errorf( "MP4File::FindBytesProperty - %s", msg.str().c_str() );
+        return;
     }
 }
 
 void MP4File::GetBytesProperty(const char* name,
                                uint8_t** ppValue, uint32_t* pValueSize)
 {
-    MP4Property* pProperty;
-    uint32_t index;
+   MP4Property* pProperty = nullptr;
+   uint32_t index;
 
-    FindBytesProperty(name, &pProperty, &index);
+   FindBytesProperty(name, &pProperty, &index);
 
-    ((MP4BytesProperty*)pProperty)->GetValue(ppValue, pValueSize, index);
+   if ( pProperty != nullptr )
+      ((MP4BytesProperty*)pProperty)->GetValue(ppValue, pValueSize, index);
 }
 
 void MP4File::SetBytesProperty(const char* name,
@@ -889,12 +902,13 @@ void MP4File::SetBytesProperty(const char* name,
 {
     ProtectWriteOperation(__FILE__, __LINE__, __FUNCTION__);
 
-    MP4Property* pProperty;
+    MP4Property* pProperty = nullptr;
     uint32_t index;
 
     FindBytesProperty(name, &pProperty, &index);
 
-    ((MP4BytesProperty*)pProperty)->SetValue(pValue, valueSize, index);
+    if ( pProperty != nullptr )
+      ((MP4BytesProperty*)pProperty)->SetValue(pValue, valueSize, index);
 }
 
 


### PR DESCRIPTION
Apparently videos created by WhatsApp are somewhat out-of-spec. The errors seem relatively harmless though since the videos seem to work just fine in most player apps. This change generally makes parsing a little more tolerant by replacing some exception throwing with error logging.