### PR TITLE
Revert earlier commit

### DIFF
--- a/src/mp4file.cpp
+++ b/src/mp4file.cpp
@@ -745,8 +745,7 @@ void MP4File::FindIntegerProperty(const char* name,
     if ( !FindProperty( name, ppProperty, pIndex ) ) {
         ostringstream msg;
         msg << "no such property - " << name;
-        log.errorf( "MP4File::FindIntegerProperty - %s", msg.str().c_str() );
-        return;
+        throw new Exception( msg.str(), __FILE__, __LINE__, __FUNCTION__ );
     }
 
     switch ((*ppProperty)->GetType()) {


### PR DESCRIPTION
An earlier commit updated `MP4File::FindIntegerProperty()` to no longer throw a "no such property" exception. It turns out that mp4v2 internally relies on this behavior for looking up a video track width and height. That was causing problems, obviously, and it turned out I didn't really need that change for the problem I was trying to solve. I didn't realize there was a problem until trying to pull mp4v2 into another repo since mp4v2 doesn't directly have any test coverage.