### PR TITLE
Revert throw removal in FindBytesProperty

### DIFF
--- a/src/mp4file.cpp
+++ b/src/mp4file.cpp
@@ -873,14 +873,12 @@ void MP4File::FindBytesProperty(const char* name,
     if (!FindProperty(name, ppProperty, pIndex)) {
         ostringstream msg;
         msg << "no such property " << name;
-        log.errorf( "MP4File::FindBytesProperty - %s", msg.str().c_str() );
-        return;
+        throw new Exception(msg.str(), __FILE__, __LINE__, __FUNCTION__);
     }
     if ((*ppProperty)->GetType() != BytesProperty) {
         ostringstream msg;
         msg << "type mismatch - property " << name << " - type " <<  (*ppProperty)->GetType();
-        log.errorf( "MP4File::FindBytesProperty - %s", msg.str().c_str() );
-        return;
+        throw new Exception(msg.str(), __FILE__, __LINE__, __FUNCTION__);
     }
 }
 


### PR DESCRIPTION
from 7104b13ebf54813c221d9f64d941734fc7e950ad

This throw was being relied on in GetTrackESConfiguration:
![image](https://github.com/user-attachments/assets/7d03d68e-cbd8-4f4a-b67e-2125b7ca6fca)

If one string wasn't found it would catch and try another. That's the one that actually works for decoding audio on macOS apparently:
![image](https://github.com/user-attachments/assets/f0c187df-1c71-4e3f-9a7e-41beb8f0f9ce)

This makes me think we should revert the rest of that commit, but I can't find anything else like this in mp4file.cpp at least

