### PR TITLE
Pull in bug fixes from a newer fork of this repo

### DIFF
--- a/src/atom_rtp.cpp
+++ b/src/atom_rtp.cpp
@@ -127,10 +127,19 @@ void MP4RtpAtom::ReadHntiType()
     uint64_t size = GetEnd() - m_File.GetPosition();
     char* data = (char*)MP4Malloc(size + 1);
     ASSERT(data != NULL);
-    m_File.ReadBytes((uint8_t*)data, size);
-    data[size] = '\0';
-    ((MP4StringProperty*)m_pProperties[1])->SetValue(data);
-    MP4Free(data);
+    try
+    {
+       m_File.ReadBytes( (uint8_t*)data, size );
+       data[size] = '\0';
+       ( (MP4StringProperty*)m_pProperties[1] )->SetValue( data );
+       MP4Free( data );
+    }
+    catch (Exception*)
+    {
+       // free memory and rethrow
+       MP4Free( data );
+       throw;
+    }
 }
 
 void MP4RtpAtom::Write()

--- a/src/atom_sdp.cpp
+++ b/src/atom_sdp.cpp
@@ -38,10 +38,19 @@ void MP4SdpAtom::Read()
     uint64_t size = GetEnd() - m_File.GetPosition();
     char* data = (char*)MP4Malloc(size + 1);
     ASSERT(data != NULL);
-    m_File.ReadBytes((uint8_t*)data, size);
-    data[size] = '\0';
-    ((MP4StringProperty*)m_pProperties[0])->SetValue(data);
-    MP4Free(data);
+    try
+    {
+       m_File.ReadBytes( (uint8_t*)data, size );
+       data[size] = '\0';
+       ( (MP4StringProperty*)m_pProperties[0] )->SetValue( data );
+       MP4Free( data );
+    }
+    catch (Exception*)
+    {
+       // free memory and rethrow
+       MP4Free( data );
+       throw;
+    }
 }
 
 void MP4SdpAtom::Write()

--- a/src/mp4.cpp
+++ b/src/mp4.cpp
@@ -444,7 +444,7 @@ MP4FileHandle MP4ReadProvider( const char* fileName, const MP4FileProvider* file
                                                    &foo,
                                                    &bufsize)) {
                         uint8_t *ptr = foo;
-                        while (bufsize > 0) {
+                        while (bufsize >= 5) {
                             if (MP4V2_HTONL(*(uint32_t *)ptr) == 0x1b0) {
                                 uint8_t ret = ptr[4];
                                 free(foo);

--- a/src/mp4property.cpp
+++ b/src/mp4property.cpp
@@ -339,9 +339,13 @@ MP4StringProperty::~MP4StringProperty()
     }
 }
 
-void MP4StringProperty::SetCount(uint32_t count)
+void MP4StringProperty::SetCount( uint32_t count )
 {
-    uint32_t oldCount = m_values.Size();
+   uint32_t oldCount = m_values.Size();
+   for (uint32_t i = count; i < oldCount; ++i)
+   {
+      MP4Free( m_values[i] );
+   }
 
     m_values.Resize(count);
 
@@ -508,7 +512,11 @@ MP4BytesProperty::~MP4BytesProperty()
 
 void MP4BytesProperty::SetCount(uint32_t count)
 {
-    uint32_t oldCount = m_values.Size();
+   uint32_t oldCount = m_values.Size();
+   for ( uint32_t i = count; i < oldCount; ++i )
+   {
+      MP4Free( m_values[i] );
+   }
 
     m_values.Resize(count);
     m_valueSizes.Resize(count);

--- a/src/mp4track.cpp
+++ b/src/mp4track.cpp
@@ -1392,6 +1392,10 @@ bool MP4Track::IsSyncSample(MP4SampleId sampleId)
     }
 
     uint32_t numStss = m_pStssCountProperty->GetValue();
+    if (numStss == 0)
+    {
+       return false;
+    }
     uint32_t stssLIndex = 0;
     uint32_t stssRIndex = numStss - 1;
 

--- a/src/mp4track.cpp
+++ b/src/mp4track.cpp
@@ -995,6 +995,8 @@ uint64_t MP4Track::GetSampleFileOffset(MP4SampleId sampleId)
 
     uint32_t samplesPerChunk =
         m_pStscSamplesPerChunkProperty->GetValue(stscIndex);
+    if ( samplesPerChunk == 0u )
+       throw new Exception( "Invalid number of samples in stsc entry", __FILE__, __LINE__, __FUNCTION__ );
 
     // chunkId tells which is the absolute chunk number that this sample
     // is stored in.


### PR DESCRIPTION
This pulls in some fixes from https://github.com/enzo1982/mp4v2 which is a newer fork of the same repo. These are actually not "new" fixes. The last commit there was in May 2023.

These are all relatively small code changes. More-or-less more error checking and fixing a couple of potential memory leaks.

I verified that all of the following are addressed. There were one or two where it'd already been addressed in our repo:
* CVE-2023-33720
* CVE-2023-33719
* CVE-2023-33718
* CVE-2023-33717
* CVE-2023-33716
* CVE-2023-29584
* CVE-2023-25978
* CVE-2023-1451

CVE-2023-1450 was not relevant to us; it references code that we don't have in our fork.

The full list of CVEs is here: https://nvd.nist.gov/vuln/search#/nvd/home?keyword=mp4v2&resultType=records