### PR TITLE
Add bounds check in Tags::fetchTrack to prevent heap buffer overflow

### DIFF
--- a/src/itmf/Tags.cpp
+++ b/src/itmf/Tags.cpp
@@ -471,7 +471,7 @@ Tags::fetchTrack( const CodeItemMap& cim, MP4TagTrack& cpp, const MP4TagTrack*& 
 
     MP4ItmfData& data = f->second->dataList.elements[0];
 
-    if( NULL == data.value )
+    if( NULL == data.value || data.valueSize < 6 )
         return;
 
     cpp.index = (uint16_t(data.value[2]) <<  8)


### PR DESCRIPTION
When a malformed file carries a `trkn` metadata atom whose data value is shorter than 6 bytes, `fetchTrack` reads `value[2]` through `value[5]` past the end of the heap buffer. The other fetch helpers have the same shape, but this is the one reported in #90; mp4info crashes under AddressSanitizer on such a file. This adds a `valueSize >= 6` check alongside the existing NULL guard so the short value is skipped instead. Fixes #90.